### PR TITLE
Github Actions fixup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,7 +147,7 @@ jobs:
         path: build2/*
         retention-days: 2
   build-win:
-    runs-on: windows-2016
+    runs-on: windows-2019
     strategy:
       fail-fast: false
       matrix:
@@ -456,7 +456,7 @@ jobs:
         retention-days: 2  
     
   build-win-python:
-    runs-on: windows-2016
+    runs-on: windows-2019
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -719,7 +719,7 @@ jobs:
         ctest . -C Release --output-on-failure
 
   build-conda-osx:
-    runs-on: macos-10.15
+    runs-on: macos-11
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
Use windows-2019 for Windows builds after windows-2016 has been removed. Use macos-12 for conda osx build.