### PR TITLE
Create nodeid config directory for users on Linux

### DIFF
--- a/RobotRaconteurCore/src/NodeDirectories.cpp
+++ b/RobotRaconteurCore/src/NodeDirectories.cpp
@@ -679,9 +679,7 @@ GetUuidForNameAndLockResult GetUuidForNameAndLock(const NodeDirectories& node_di
         p /= s;
     }
 
-#ifdef ROBOTRACONTEUR_WINDOWS
     boost::filesystem::create_directories(p);
-#endif
     p /= name.to_string();
 
 #ifdef ROBOTRACONTEUR_WINDOWS


### PR DESCRIPTION
This fixes `RobotRaconteurException: RobotRaconteur.SystemResourceError: Could not initialize UUID store` error on Linux when starting LocalTransport server.