### PR TITLE
Improve Subscription features and fix IntraTransport discovery

### DIFF
--- a/RobotRaconteurCore/include/RobotRaconteur/IntraTransport.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/IntraTransport.h
@@ -114,6 +114,12 @@ class ROBOTRACONTEUR_CORE_API IntraTransport : public Transport, public RR_ENABL
      */
     virtual void StartServer();
 
+    /**
+     * @brief Start the transport as a client
+     * 
+     */
+    virtual void StartClient();
+
   protected:
     virtual void CloseTransportConnection_timed(const boost::system::error_code& err, const RR_SHARED_PTR<Endpoint>& e,
                                                 const RR_SHARED_PTR<void>& timer);
@@ -155,6 +161,8 @@ class ROBOTRACONTEUR_CORE_API IntraTransport : public Transport, public RR_ENABL
     RR_OVIRTUAL void LocalNodeServicesChanged() RR_OVERRIDE;
 
     void SendNodeDiscovery();
+
+    void DiscoverAllNodes();
 
   protected:
     virtual void register_transport(const RR_SHARED_PTR<ITransportConnection>& connection);

--- a/RobotRaconteurCore/include/RobotRaconteur/IntraTransport.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/IntraTransport.h
@@ -116,7 +116,7 @@ class ROBOTRACONTEUR_CORE_API IntraTransport : public Transport, public RR_ENABL
 
     /**
      * @brief Start the transport as a client
-     * 
+     *
      */
     virtual void StartClient();
 

--- a/RobotRaconteurCore/include/RobotRaconteur/Subscription.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/Subscription.h
@@ -238,6 +238,9 @@ class ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttributeGroup
         /** @brief The operation to use for matching the attributes and groups */
         ServiceSubscriptionFilterAttributeGroupOperation Operation;
 
+        bool SplitStringAttribute;
+        char SplitStringDelimiter;
+
         /**
          * @brief Construct a new Service Subscription Filter Attribute Group object
          * 
@@ -263,6 +266,9 @@ class ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttributeGroup
          * @param groups The nested groups in the group
          */
         ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation, std::vector<ServiceSubscriptionFilterAttributeGroup> groups);
+
+        bool IsMatch(boost::string_ref value) const;
+        bool IsMatch(RR_INTRUSIVE_PTR<RRArray<char> >& value) const;
 
         /**
          * @brief Compare the group to a list of values
@@ -296,6 +302,8 @@ class ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttributeGroup
          * @return false 
          */
         bool IsMatch(const std::map<std::string, std::string>& values) const;
+
+        bool IsMatch(const RR_INTRUSIVE_PTR<RRValue>& value) const;
 };
 
 /**
@@ -318,6 +326,8 @@ class ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilter
     std::vector<std::string> TransportSchemes;
     /** Attributes to match */
     std::map<std::string,ServiceSubscriptionFilterAttributeGroup> Attributes;
+    /** Operation to use to match attributes. Defaults to AND */
+    ServiceSubscriptionFilterAttributeGroupOperation AttributesMatchOperation;
     /** A user specified predicate function. If nullptr, the predicate is not checked. **/
     boost::function<bool(const ServiceInfo2&)> Predicate;
     /** The maximum number of connections the subscription will create. Zero means unlimited connections. **/

--- a/RobotRaconteurCore/include/RobotRaconteur/Subscription.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/Subscription.h
@@ -238,7 +238,9 @@ class ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttributeGroup
         /** @brief The operation to use for matching the attributes and groups */
         ServiceSubscriptionFilterAttributeGroupOperation Operation;
 
+        /** @brief True if string attributes will be split into a list with delimiter (default ",") */
         bool SplitStringAttribute;
+        /** @brief Delimiter to use to split string attributes (default ",")*/
         char SplitStringDelimiter;
 
         /**
@@ -267,7 +269,22 @@ class ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttributeGroup
          */
         ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation, std::vector<ServiceSubscriptionFilterAttributeGroup> groups);
 
+        /**
+         * @brief Compare the group to a value
+         * 
+         * @param value The value to compare
+         * @return true 
+         * @return false 
+         */
         bool IsMatch(boost::string_ref value) const;
+
+        /**
+         * @brief Compare the group to a value
+         * 
+         * @param value The value to compare
+         * @return true 
+         * @return false 
+         */
         bool IsMatch(RR_INTRUSIVE_PTR<RRArray<char> >& value) const;
 
         /**

--- a/RobotRaconteurCore/include/RobotRaconteur/Subscription.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/Subscription.h
@@ -668,6 +668,18 @@ class ROBOTRACONTEUR_CORE_API ServiceSubscription : public IServiceSubscription,
                               (RR_INTRUSIVE_PTR<RRMap<std::string, RRValue> >()),
                           boost::string_ref object_type = "", bool close_connected = false);
 
+    /**
+     * @brief Update the service type and filter for subscription
+     *
+     * Updates the existing target service types and filter for a running subscription
+     *
+     * @param service_types A std::vector of service types to listen for, ie `com.robotraconteur.robotics.robot.Robot`
+     * @param filter A filter to select individual services based on specified criteria
+     */
+
+    void UpdateServiceByType(const std::vector<std::string>& service_types,
+        const RR_SHARED_PTR<ServiceSubscriptionFilter>& filter = RR_SHARED_PTR<ServiceSubscriptionFilter>());
+
     RR_SHARED_PTR<RobotRaconteurNode> GetNode();
 
   protected:

--- a/RobotRaconteurCore/include/RobotRaconteur/Subscription.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/Subscription.h
@@ -83,6 +83,222 @@ class ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterNode
 };
 
 /**
+ * @brief Subscription filter attribute for use with ServiceSubscriptionFilter
+ * 
+ */
+class ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttribute
+{
+    public:
+        /** @brief The attribute name. Empty for no name */
+        std::string Name;
+        /** @brief The string value of the attribute */
+        std::string Value;
+        /** @brief The regex value of the attribute */
+        boost::regex ValueRegex;
+        /** @brief True if ValueRegex is used, otherwise Value is matched */
+        bool UseRegex;
+
+        /**
+         * @brief Construct a new Service Subscription Filter Attribute object
+         * 
+         */
+        ServiceSubscriptionFilterAttribute();
+        /**
+         * @brief Construct a new Service Subscription Filter Attribute object
+         * 
+         * This is a nameless attribute for use with attribute lists
+         * 
+         * @param value The attribute value
+         */
+        ServiceSubscriptionFilterAttribute(boost::string_ref value);
+        /**
+         * @brief Construct a new Service Subscription Filter Attribute object
+         * 
+         * This is a nameless attribute for use with attribute lists. The value is compared using a regex
+         * 
+         * @param value_regex The attribute value regex
+         */
+        ServiceSubscriptionFilterAttribute(boost::regex value_regex);
+        /**
+         * @brief Construct a new Service Subscription Filter Attribute object
+         * 
+         * This is a named attribute for use with attribute maps
+         * 
+         * @param name The attribute name
+         * @param value The attribute value
+         */
+        ServiceSubscriptionFilterAttribute(boost::string_ref name, boost::string_ref value);
+
+        /**
+         * @brief Construct a new Service Subscription Filter Attribute object
+         * 
+         * This is a named attribute for use with attribute maps. The value is compared using a regex
+         * 
+         * @param name The attribute name
+         * @param value_regex The attribute value regex
+         */
+        ServiceSubscriptionFilterAttribute(boost::string_ref name, boost::regex value_regex);
+
+        /**
+         * @brief Compare the attribute to a value
+         * 
+         * @param value The value to compare
+         * @return true 
+         * @return false 
+         */
+        bool IsMatch(boost::string_ref value) const;
+        /**
+         * @brief Compare the attribute to a named value
+         * 
+         * @param name The name to compare
+         * @param value The value to compare
+         * @return true 
+         * @return false 
+         */
+        bool IsMatch(boost::string_ref name, boost::string_ref value) const;
+        /**
+         * @brief Compare the attribute to a value list using OR logic
+         * 
+         * @param values The values to compare
+         * @return true 
+         * @return false 
+         */
+        bool IsMatch(const std::vector<std::string>& values) const;
+        /**
+         * @brief Compare the attribute to a value list using OR logic
+         * 
+         * @param values The values to compare
+         * @return true 
+         * @return false 
+         */
+        bool IsMatch(const RR_INTRUSIVE_PTR<RRList<RRValue> >& values) const;
+        /**
+         * @brief Compare the attribute to a value map using OR logic
+         * 
+         * @param values The value map to compare
+         * @return true 
+         * @return false 
+         */
+        bool IsMatch(const RR_INTRUSIVE_PTR<RRMap<std::string, RRValue> >& values) const;
+        /**
+         * @brief Compare the attribute to a value map using OR logic
+         * 
+         * @param values The value map to compare
+         * @return true 
+         * @return false 
+         */
+        bool IsMatch(const std::map<std::string, std::string>& values) const;
+};
+
+/**
+ * @brief Create a ServiceSubscriptionFilterAttribute from a regex string
+ * 
+ * @param regex_value The regex string to compile
+ * @return ServiceSubscriptionFilterAttribute The created attribute
+ */ 
+ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttribute CreateServiceSubscriptionFilterAttributeRegex(boost::string_ref regex_value);
+/**
+ * @brief Create a ServiceSubscriptionFilterAttribute from a regex string
+ * 
+ * @param name The attribute name
+ * @param regex_value The regex string to compile
+ * @return ROBOTRACONTEUR_CORE_API 
+ */
+ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttribute CreateServiceSubscriptionFilterAttributeRegex(boost::string_ref name, boost::string_ref regex_value);
+
+/**
+ * @brief Comparison operations for ServiceSubscriptionFilterAttributeGroup
+ * 
+ */
+enum ServiceSubscriptionFilterAttributeGroupOperation
+{
+    /** @brief OR operation */
+    ServiceSubscriptionFilterAttributeGroupOperation_OR,
+    /** @brief AND operation */
+    ServiceSubscriptionFilterAttributeGroupOperation_AND,
+    /** @brief NOR operation. Also used for NOT */
+    ServiceSubscriptionFilterAttributeGroupOperation_NOR,
+    /** @brief NAND operation */
+    ServiceSubscriptionFilterAttributeGroupOperation_NAND
+};
+
+/**
+ * @brief Subscription filter attribute group for use with ServiceSubscriptionFilter
+ * 
+ * Used to combine multiple ServiceSubscriptionFilterAttribute objects for comparison using
+ * AND, OR, NOR, or NAND logic. Other groups can be nested, to allow for complex comparisons.
+ */
+class ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttributeGroup
+{
+    public:
+        /** @brief The attributes in the group */
+        std::vector<ServiceSubscriptionFilterAttribute> Attributes;
+        /** @brief The nested groups in the group */
+        std::vector<ServiceSubscriptionFilterAttributeGroup> Groups;
+        /** @brief The operation to use for matching the attributes and groups */
+        ServiceSubscriptionFilterAttributeGroupOperation Operation;
+
+        /**
+         * @brief Construct a new Service Subscription Filter Attribute Group object
+         * 
+         */
+        ServiceSubscriptionFilterAttributeGroup();
+        /**
+         * @brief Construct a new Service Subscription Filter Attribute Group object
+         * 
+         * @param operation The operation to use for matching the attributes and groups
+         */
+        ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation);
+        /**
+         * @brief Construct a new Service Subscription Filter Attribute Group object
+         * 
+         * @param operation The operation to use for matching the attributes and groups
+         * @param attributes The attributes in the group
+         */
+        ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation, std::vector<ServiceSubscriptionFilterAttribute> attributes);
+        /**
+         * @brief Construct a new Service Subscription Filter Attribute Group object
+         * 
+         * @param operation The operation to use for matching the attributes and groups
+         * @param groups The nested groups in the group
+         */
+        ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation, std::vector<ServiceSubscriptionFilterAttributeGroup> groups);
+
+        /**
+         * @brief Compare the group to a list of values
+         * 
+         * @param values The values to compare
+         * @return true 
+         * @return false 
+         */
+        bool IsMatch(const std::vector<std::string>& values) const;
+        /**
+         * @brief Compare the group to a list of values
+         * 
+         * @param values The values to compare
+         * @return true 
+         * @return false 
+         */
+        bool IsMatch(const RR_INTRUSIVE_PTR<RRList<RRValue> >& values) const;
+        /**
+         * @brief Compare the group to a map of values
+         * 
+         * @param values The values to compare
+         * @return true 
+         * @return false 
+         */
+        bool IsMatch(const RR_INTRUSIVE_PTR<RRMap<std::string, RRValue> >& values) const;
+        /**
+         * @brief Compare the group to a map of values
+         * 
+         * @param values The values to compare
+         * @return true 
+         * @return false 
+         */
+        bool IsMatch(const std::map<std::string, std::string>& values) const;
+};
+
+/**
  * @brief Subscription filter
  *
  * The subscription filter is used with RobotRaconteurNode::SubscribeServiceByType() and
@@ -100,6 +316,8 @@ class ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilter
     std::vector<std::string> ServiceNames;
     /** Vector of transport schemes. Empty means match any transport scheme. **/
     std::vector<std::string> TransportSchemes;
+    /** Attributes to match */
+    std::map<std::string,ServiceSubscriptionFilterAttributeGroup> Attributes;
     /** A user specified predicate function. If nullptr, the predicate is not checked. **/
     boost::function<bool(const ServiceInfo2&)> Predicate;
     /** The maximum number of connections the subscription will create. Zero means unlimited connections. **/

--- a/RobotRaconteurCore/include/RobotRaconteur/Subscription.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/Subscription.h
@@ -84,131 +84,133 @@ class ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterNode
 
 /**
  * @brief Subscription filter attribute for use with ServiceSubscriptionFilter
- * 
+ *
  */
 class ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttribute
 {
-    public:
-        /** @brief The attribute name. Empty for no name */
-        std::string Name;
-        /** @brief The string value of the attribute */
-        std::string Value;
-        /** @brief The regex value of the attribute */
-        boost::regex ValueRegex;
-        /** @brief True if ValueRegex is used, otherwise Value is matched */
-        bool UseRegex;
+  public:
+    /** @brief The attribute name. Empty for no name */
+    std::string Name;
+    /** @brief The string value of the attribute */
+    std::string Value;
+    /** @brief The regex value of the attribute */
+    boost::regex ValueRegex;
+    /** @brief True if ValueRegex is used, otherwise Value is matched */
+    bool UseRegex;
 
-        /**
-         * @brief Construct a new Service Subscription Filter Attribute object
-         * 
-         */
-        ServiceSubscriptionFilterAttribute();
-        /**
-         * @brief Construct a new Service Subscription Filter Attribute object
-         * 
-         * This is a nameless attribute for use with attribute lists
-         * 
-         * @param value The attribute value
-         */
-        ServiceSubscriptionFilterAttribute(boost::string_ref value);
-        /**
-         * @brief Construct a new Service Subscription Filter Attribute object
-         * 
-         * This is a nameless attribute for use with attribute lists. The value is compared using a regex
-         * 
-         * @param value_regex The attribute value regex
-         */
-        ServiceSubscriptionFilterAttribute(const boost::regex& value_regex);
-        /**
-         * @brief Construct a new Service Subscription Filter Attribute object
-         * 
-         * This is a named attribute for use with attribute maps
-         * 
-         * @param name The attribute name
-         * @param value The attribute value
-         */
-        ServiceSubscriptionFilterAttribute(boost::string_ref name, boost::string_ref value);
+    /**
+     * @brief Construct a new Service Subscription Filter Attribute object
+     *
+     */
+    ServiceSubscriptionFilterAttribute();
+    /**
+     * @brief Construct a new Service Subscription Filter Attribute object
+     *
+     * This is a nameless attribute for use with attribute lists
+     *
+     * @param value The attribute value
+     */
+    ServiceSubscriptionFilterAttribute(boost::string_ref value);
+    /**
+     * @brief Construct a new Service Subscription Filter Attribute object
+     *
+     * This is a nameless attribute for use with attribute lists. The value is compared using a regex
+     *
+     * @param value_regex The attribute value regex
+     */
+    ServiceSubscriptionFilterAttribute(const boost::regex& value_regex);
+    /**
+     * @brief Construct a new Service Subscription Filter Attribute object
+     *
+     * This is a named attribute for use with attribute maps
+     *
+     * @param name The attribute name
+     * @param value The attribute value
+     */
+    ServiceSubscriptionFilterAttribute(boost::string_ref name, boost::string_ref value);
 
-        /**
-         * @brief Construct a new Service Subscription Filter Attribute object
-         * 
-         * This is a named attribute for use with attribute maps. The value is compared using a regex
-         * 
-         * @param name The attribute name
-         * @param value_regex The attribute value regex
-         */
-        ServiceSubscriptionFilterAttribute(boost::string_ref name, const boost::regex& value_regex);
+    /**
+     * @brief Construct a new Service Subscription Filter Attribute object
+     *
+     * This is a named attribute for use with attribute maps. The value is compared using a regex
+     *
+     * @param name The attribute name
+     * @param value_regex The attribute value regex
+     */
+    ServiceSubscriptionFilterAttribute(boost::string_ref name, const boost::regex& value_regex);
 
-        /**
-         * @brief Compare the attribute to a value
-         * 
-         * @param value The value to compare
-         * @return true 
-         * @return false 
-         */
-        bool IsMatch(boost::string_ref value) const;
-        /**
-         * @brief Compare the attribute to a named value
-         * 
-         * @param name The name to compare
-         * @param value The value to compare
-         * @return true 
-         * @return false 
-         */
-        bool IsMatch(boost::string_ref name, boost::string_ref value) const;
-        /**
-         * @brief Compare the attribute to a value list using OR logic
-         * 
-         * @param values The values to compare
-         * @return true 
-         * @return false 
-         */
-        bool IsMatch(const std::vector<std::string>& values) const;
-        /**
-         * @brief Compare the attribute to a value list using OR logic
-         * 
-         * @param values The values to compare
-         * @return true 
-         * @return false 
-         */
-        bool IsMatch(const RR_INTRUSIVE_PTR<RRList<RRValue> >& values) const;
-        /**
-         * @brief Compare the attribute to a value map using OR logic
-         * 
-         * @param values The value map to compare
-         * @return true 
-         * @return false 
-         */
-        bool IsMatch(const RR_INTRUSIVE_PTR<RRMap<std::string, RRValue> >& values) const;
-        /**
-         * @brief Compare the attribute to a value map using OR logic
-         * 
-         * @param values The value map to compare
-         * @return true 
-         * @return false 
-         */
-        bool IsMatch(const std::map<std::string, std::string>& values) const;
+    /**
+     * @brief Compare the attribute to a value
+     *
+     * @param value The value to compare
+     * @return true
+     * @return false
+     */
+    bool IsMatch(boost::string_ref value) const;
+    /**
+     * @brief Compare the attribute to a named value
+     *
+     * @param name The name to compare
+     * @param value The value to compare
+     * @return true
+     * @return false
+     */
+    bool IsMatch(boost::string_ref name, boost::string_ref value) const;
+    /**
+     * @brief Compare the attribute to a value list using OR logic
+     *
+     * @param values The values to compare
+     * @return true
+     * @return false
+     */
+    bool IsMatch(const std::vector<std::string>& values) const;
+    /**
+     * @brief Compare the attribute to a value list using OR logic
+     *
+     * @param values The values to compare
+     * @return true
+     * @return false
+     */
+    bool IsMatch(const RR_INTRUSIVE_PTR<RRList<RRValue> >& values) const;
+    /**
+     * @brief Compare the attribute to a value map using OR logic
+     *
+     * @param values The value map to compare
+     * @return true
+     * @return false
+     */
+    bool IsMatch(const RR_INTRUSIVE_PTR<RRMap<std::string, RRValue> >& values) const;
+    /**
+     * @brief Compare the attribute to a value map using OR logic
+     *
+     * @param values The value map to compare
+     * @return true
+     * @return false
+     */
+    bool IsMatch(const std::map<std::string, std::string>& values) const;
 };
 
 /**
  * @brief Create a ServiceSubscriptionFilterAttribute from a regex string
- * 
+ *
  * @param regex_value The regex string to compile
  * @return ServiceSubscriptionFilterAttribute The created attribute
- */ 
-ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttribute CreateServiceSubscriptionFilterAttributeRegex(boost::string_ref regex_value);
+ */
+ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttribute
+CreateServiceSubscriptionFilterAttributeRegex(boost::string_ref regex_value);
 /**
  * @brief Create a ServiceSubscriptionFilterAttribute from a regex string
- * 
+ *
  * @param name The attribute name
  * @param regex_value The regex string to compile
- * @return ROBOTRACONTEUR_CORE_API 
+ * @return ROBOTRACONTEUR_CORE_API
  */
-ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttribute CreateServiceSubscriptionFilterAttributeRegex(boost::string_ref name, boost::string_ref regex_value);
+ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttribute
+CreateServiceSubscriptionFilterAttributeRegex(boost::string_ref name, boost::string_ref regex_value);
 
 /**
  * @brief Comparison operations for ServiceSubscriptionFilterAttributeGroup
- * 
+ *
  */
 enum ServiceSubscriptionFilterAttributeGroupOperation
 {
@@ -224,103 +226,105 @@ enum ServiceSubscriptionFilterAttributeGroupOperation
 
 /**
  * @brief Subscription filter attribute group for use with ServiceSubscriptionFilter
- * 
+ *
  * Used to combine multiple ServiceSubscriptionFilterAttribute objects for comparison using
  * AND, OR, NOR, or NAND logic. Other groups can be nested, to allow for complex comparisons.
  */
 class ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttributeGroup
 {
-    public:
-        /** @brief The attributes in the group */
-        std::vector<ServiceSubscriptionFilterAttribute> Attributes;
-        /** @brief The nested groups in the group */
-        std::vector<ServiceSubscriptionFilterAttributeGroup> Groups;
-        /** @brief The operation to use for matching the attributes and groups */
-        ServiceSubscriptionFilterAttributeGroupOperation Operation;
+  public:
+    /** @brief The attributes in the group */
+    std::vector<ServiceSubscriptionFilterAttribute> Attributes;
+    /** @brief The nested groups in the group */
+    std::vector<ServiceSubscriptionFilterAttributeGroup> Groups;
+    /** @brief The operation to use for matching the attributes and groups */
+    ServiceSubscriptionFilterAttributeGroupOperation Operation;
 
-        /** @brief True if string attributes will be split into a list with delimiter (default ",") */
-        bool SplitStringAttribute;
-        /** @brief Delimiter to use to split string attributes (default ",")*/
-        char SplitStringDelimiter;
+    /** @brief True if string attributes will be split into a list with delimiter (default ",") */
+    bool SplitStringAttribute;
+    /** @brief Delimiter to use to split string attributes (default ",")*/
+    char SplitStringDelimiter;
 
-        /**
-         * @brief Construct a new Service Subscription Filter Attribute Group object
-         * 
-         */
-        ServiceSubscriptionFilterAttributeGroup();
-        /**
-         * @brief Construct a new Service Subscription Filter Attribute Group object
-         * 
-         * @param operation The operation to use for matching the attributes and groups
-         */
-        ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation);
-        /**
-         * @brief Construct a new Service Subscription Filter Attribute Group object
-         * 
-         * @param operation The operation to use for matching the attributes and groups
-         * @param attributes The attributes in the group
-         */
-        ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation, std::vector<ServiceSubscriptionFilterAttribute> attributes);
-        /**
-         * @brief Construct a new Service Subscription Filter Attribute Group object
-         * 
-         * @param operation The operation to use for matching the attributes and groups
-         * @param groups The nested groups in the group
-         */
-        ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation, std::vector<ServiceSubscriptionFilterAttributeGroup> groups);
+    /**
+     * @brief Construct a new Service Subscription Filter Attribute Group object
+     *
+     */
+    ServiceSubscriptionFilterAttributeGroup();
+    /**
+     * @brief Construct a new Service Subscription Filter Attribute Group object
+     *
+     * @param operation The operation to use for matching the attributes and groups
+     */
+    ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation);
+    /**
+     * @brief Construct a new Service Subscription Filter Attribute Group object
+     *
+     * @param operation The operation to use for matching the attributes and groups
+     * @param attributes The attributes in the group
+     */
+    ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation,
+                                            std::vector<ServiceSubscriptionFilterAttribute> attributes);
+    /**
+     * @brief Construct a new Service Subscription Filter Attribute Group object
+     *
+     * @param operation The operation to use for matching the attributes and groups
+     * @param groups The nested groups in the group
+     */
+    ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation,
+                                            std::vector<ServiceSubscriptionFilterAttributeGroup> groups);
 
-        /**
-         * @brief Compare the group to a value
-         * 
-         * @param value The value to compare
-         * @return true 
-         * @return false 
-         */
-        bool IsMatch(boost::string_ref value) const;
+    /**
+     * @brief Compare the group to a value
+     *
+     * @param value The value to compare
+     * @return true
+     * @return false
+     */
+    bool IsMatch(boost::string_ref value) const;
 
-        /**
-         * @brief Compare the group to a value
-         * 
-         * @param value The value to compare
-         * @return true 
-         * @return false 
-         */
-        bool IsMatch(RR_INTRUSIVE_PTR<RRArray<char> >& value) const;
+    /**
+     * @brief Compare the group to a value
+     *
+     * @param value The value to compare
+     * @return true
+     * @return false
+     */
+    bool IsMatch(RR_INTRUSIVE_PTR<RRArray<char> >& value) const;
 
-        /**
-         * @brief Compare the group to a list of values
-         * 
-         * @param values The values to compare
-         * @return true 
-         * @return false 
-         */
-        bool IsMatch(const std::vector<std::string>& values) const;
-        /**
-         * @brief Compare the group to a list of values
-         * 
-         * @param values The values to compare
-         * @return true 
-         * @return false 
-         */
-        bool IsMatch(const RR_INTRUSIVE_PTR<RRList<RRValue> >& values) const;
-        /**
-         * @brief Compare the group to a map of values
-         * 
-         * @param values The values to compare
-         * @return true 
-         * @return false 
-         */
-        bool IsMatch(const RR_INTRUSIVE_PTR<RRMap<std::string, RRValue> >& values) const;
-        /**
-         * @brief Compare the group to a map of values
-         * 
-         * @param values The values to compare
-         * @return true 
-         * @return false 
-         */
-        bool IsMatch(const std::map<std::string, std::string>& values) const;
+    /**
+     * @brief Compare the group to a list of values
+     *
+     * @param values The values to compare
+     * @return true
+     * @return false
+     */
+    bool IsMatch(const std::vector<std::string>& values) const;
+    /**
+     * @brief Compare the group to a list of values
+     *
+     * @param values The values to compare
+     * @return true
+     * @return false
+     */
+    bool IsMatch(const RR_INTRUSIVE_PTR<RRList<RRValue> >& values) const;
+    /**
+     * @brief Compare the group to a map of values
+     *
+     * @param values The values to compare
+     * @return true
+     * @return false
+     */
+    bool IsMatch(const RR_INTRUSIVE_PTR<RRMap<std::string, RRValue> >& values) const;
+    /**
+     * @brief Compare the group to a map of values
+     *
+     * @param values The values to compare
+     * @return true
+     * @return false
+     */
+    bool IsMatch(const std::map<std::string, std::string>& values) const;
 
-        bool IsMatch(const RR_INTRUSIVE_PTR<RRValue>& value) const;
+    bool IsMatch(const RR_INTRUSIVE_PTR<RRValue>& value) const;
 };
 
 /**
@@ -342,7 +346,7 @@ class ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilter
     /** Vector of transport schemes. Empty means match any transport scheme. **/
     std::vector<std::string> TransportSchemes;
     /** Attributes to match */
-    std::map<std::string,ServiceSubscriptionFilterAttributeGroup> Attributes;
+    std::map<std::string, ServiceSubscriptionFilterAttributeGroup> Attributes;
     /** Operation to use to match attributes. Defaults to AND */
     ServiceSubscriptionFilterAttributeGroupOperation AttributesMatchOperation;
     /** A user specified predicate function. If nullptr, the predicate is not checked. **/
@@ -922,7 +926,8 @@ class ROBOTRACONTEUR_CORE_API ServiceSubscription : public IServiceSubscription,
      * @param filter A filter to select individual services based on specified criteria
      */
 
-    void UpdateServiceByType(const std::vector<std::string>& service_types,
+    void UpdateServiceByType(
+        const std::vector<std::string>& service_types,
         const RR_SHARED_PTR<ServiceSubscriptionFilter>& filter = RR_SHARED_PTR<ServiceSubscriptionFilter>());
 
     RR_SHARED_PTR<RobotRaconteurNode> GetNode();

--- a/RobotRaconteurCore/include/RobotRaconteur/Subscription.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/Subscription.h
@@ -118,7 +118,7 @@ class ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttribute
          * 
          * @param value_regex The attribute value regex
          */
-        ServiceSubscriptionFilterAttribute(boost::regex value_regex);
+        ServiceSubscriptionFilterAttribute(const boost::regex& value_regex);
         /**
          * @brief Construct a new Service Subscription Filter Attribute object
          * 
@@ -137,7 +137,7 @@ class ROBOTRACONTEUR_CORE_API ServiceSubscriptionFilterAttribute
          * @param name The attribute name
          * @param value_regex The attribute value regex
          */
-        ServiceSubscriptionFilterAttribute(boost::string_ref name, boost::regex value_regex);
+        ServiceSubscriptionFilterAttribute(boost::string_ref name, const boost::regex& value_regex);
 
         /**
          * @brief Compare the attribute to a value

--- a/RobotRaconteurCore/src/Discovery.cpp
+++ b/RobotRaconteurCore/src/Discovery.cpp
@@ -1989,10 +1989,19 @@ void Discovery::DoSubscribe(const std::vector<std::string>& service_types,
     boost::mutex::scoped_lock lock(m_DiscoveredNodes_lock);
     subscriptions.push_back(s);
     s->Init(service_types, filter);
+    lock.unlock();
+    DoUpdateAllDetectedServices(s);
+}
 
+void Discovery::DoUpdateAllDetectedServices(const RR_SHARED_PTR<IServiceSubscription>& s)
+{
+    boost::mutex::scoped_lock lock(m_DiscoveredNodes_lock);
+    if (this->is_shutdown)
+    {
+        return;
+    }
     std::vector<RR_SHARED_PTR<Discovery_nodestorage> > storage;
     boost::range::copy(m_DiscoveredNodes | boost::adaptors::map_values, std::back_inserter(storage));
-
     lock.unlock();
 
     BOOST_FOREACH (RR_SHARED_PTR<Discovery_nodestorage>& n, storage)

--- a/RobotRaconteurCore/src/Discovery_private.h
+++ b/RobotRaconteurCore/src/Discovery_private.h
@@ -133,6 +133,8 @@ class Discovery : public RR_ENABLE_SHARED_FROM_THIS<Discovery>
     void DoSubscribe(const std::vector<std::string>& service_types,
                      const RR_SHARED_PTR<ServiceSubscriptionFilter>& filter,
                      const RR_SHARED_PTR<IServiceSubscription>& subscription);
+
+    void DoUpdateAllDetectedServices(const RR_SHARED_PTR<IServiceSubscription>& s);
 };
 
 class Discovery_updatediscoverednodes : public RR_ENABLE_SHARED_FROM_THIS<Discovery_updatediscoverednodes>

--- a/RobotRaconteurCore/src/IntraTransport.cpp
+++ b/RobotRaconteurCore/src/IntraTransport.cpp
@@ -892,7 +892,8 @@ RR_SHARED_PTR<Transport> IntraTransportConnection::GetTransport()
 void IntraTransport::DiscoverAllNodes()
 {
     RR_SHARED_PTR<RobotRaconteurNode> node = this->node.lock();
-    if (!node) return;
+    if (!node)
+        return;
 
     std::vector<NodeDiscoveryInfo> discovered_info;
     {
@@ -926,7 +927,7 @@ void IntraTransport::DiscoverAllNodes()
         }
     }
 
-    BOOST_FOREACH(NodeDiscoveryInfo n, discovered_info)
+    BOOST_FOREACH (NodeDiscoveryInfo n, discovered_info)
     {
         try
         {
@@ -934,7 +935,8 @@ void IntraTransport::DiscoverAllNodes()
         }
         catch (std::exception& e)
         {
-            ROBOTRACONTEUR_LOG_DEBUG_COMPONENT(node, Transport, 0, "Error in IntraTransport NodeDetected: " << e.what());
+            ROBOTRACONTEUR_LOG_DEBUG_COMPONENT(node, Transport, 0,
+                                               "Error in IntraTransport NodeDetected: " << e.what());
         }
     }
 }

--- a/RobotRaconteurCore/src/IntraTransport.cpp
+++ b/RobotRaconteurCore/src/IntraTransport.cpp
@@ -347,6 +347,7 @@ void IntraTransport::CloseTransportConnection_timed(const boost::system::error_c
 void IntraTransport::SendMessage(const RR_INTRUSIVE_PTR<Message>& m)
 {
 
+    m->ComputeSize();
     RR_SHARED_PTR<ITransportConnection> t;
     {
         boost::mutex::scoped_lock lock(TransportConnections_lock);
@@ -396,6 +397,7 @@ void IntraTransport::AsyncSendMessage(
     const RR_INTRUSIVE_PTR<Message>& m,
     const boost::function<void(const RR_SHARED_PTR<RobotRaconteurException>&)>& handler)
 {
+    m->ComputeSize();
     RR_SHARED_PTR<ITransportConnection> t;
     {
         boost::mutex::scoped_lock lock(TransportConnections_lock);
@@ -560,6 +562,14 @@ void IntraTransport::StartServer()
     is_server = true;
     Init();
     SendNodeDiscovery();
+    DiscoverAllNodes();
+}
+
+void IntraTransport::StartClient()
+{
+    is_server = false;
+    Init();
+    DiscoverAllNodes();
 }
 
 static void IntraTransport_NodeDetected1(RR_WEAK_PTR<RobotRaconteurNode> node, const NodeDiscoveryInfo& info)
@@ -877,6 +887,56 @@ RR_SHARED_PTR<Transport> IntraTransportConnection::GetTransport()
     if (!p)
         throw InvalidOperationException("Transport has been released");
     return p;
+}
+
+void IntraTransport::DiscoverAllNodes()
+{
+    RR_SHARED_PTR<RobotRaconteurNode> node = this->node.lock();
+    if (!node) return;
+
+    std::vector<NodeDiscoveryInfo> discovered_info;
+    {
+        boost::mutex::scoped_lock lock(peer_transports_lock);
+        for (std::list<RR_WEAK_PTR<IntraTransport> >::iterator ee = peer_transports.begin();
+             ee != peer_transports.end();)
+        {
+            RR_SHARED_PTR<IntraTransport> peer = ee->lock();
+            if (!peer)
+            {
+                ee = peer_transports.erase(ee);
+                continue;
+            }
+            ++ee;
+
+            if (!peer->IsServer())
+            {
+                continue;
+            }
+
+            NodeDiscoveryInfo n;
+            if (peer->TryGetNodeInfo(n.NodeID, n.NodeName, n.ServiceStateNonce))
+            {
+                NodeDiscoveryInfoURL u;
+                u.URL = "rr+intra:///?nodeid=" + n.NodeID.ToString("B") + "&service=RobotRaconteurServiceIndex";
+                u.LastAnnounceTime = boost::posix_time::microsec_clock::universal_time();
+                n.URLs.push_back(u);
+
+                discovered_info.push_back(n);
+            }
+        }
+    }
+
+    BOOST_FOREACH(NodeDiscoveryInfo n, discovered_info)
+    {
+        try
+        {
+            node->NodeDetected(n);
+        }
+        catch (std::exception& e)
+        {
+            ROBOTRACONTEUR_LOG_DEBUG_COMPONENT(node, Transport, 0, "Error in IntraTransport NodeDetected: " << e.what());
+        }
+    }
 }
 
 } // namespace RobotRaconteur

--- a/RobotRaconteurCore/src/NodeSetup.cpp
+++ b/RobotRaconteurCore/src/NodeSetup.cpp
@@ -321,6 +321,10 @@ void RobotRaconteurNodeSetup::DoSetup(const RR_SHARED_PTR<RobotRaconteurNode>& n
         {
             intra_transport->StartServer();
         }
+        else
+        {
+            intra_transport->StartClient();
+        }
 
         node->RegisterTransport(intra_transport);
     }

--- a/RobotRaconteurCore/src/Subscription.cpp
+++ b/RobotRaconteurCore/src/Subscription.cpp
@@ -3015,7 +3015,7 @@ ServiceSubscriptionFilterAttribute::ServiceSubscriptionFilterAttribute(boost::st
     this->UseRegex = false;
 }
 
-ServiceSubscriptionFilterAttribute::ServiceSubscriptionFilterAttribute(boost::regex value)
+ServiceSubscriptionFilterAttribute::ServiceSubscriptionFilterAttribute(const boost::regex& value)
 {
     this->Name = "";
     this->Value = "";

--- a/RobotRaconteurCore/src/Subscription.cpp
+++ b/RobotRaconteurCore/src/Subscription.cpp
@@ -3123,8 +3123,12 @@ bool ServiceSubscriptionFilterAttribute::IsMatch(const RR_INTRUSIVE_PTR<RRMap<st
 
         std::string s2 = RRArrayToString(s);
 
-        return IsMatch(e.first, s2);
+        if(IsMatch(e.first, s2))
+        {
+            return true;
+        }
     }
+    return false;
 }
 
 bool ServiceSubscriptionFilterAttribute::IsMatch(const std::map<std::string, std::string>& values) const

--- a/RobotRaconteurCore/src/Subscription.cpp
+++ b/RobotRaconteurCore/src/Subscription.cpp
@@ -1659,8 +1659,9 @@ void ServiceSubscription::UpdateServiceByType(const std::vector<std::string>& se
             std::vector<std::string> filter_res_urls;
             std::string filter_res;
             RR_SHARED_PTR<ServiceSubscriptionFilterNode> filter_node;
+            RR_SHARED_PTR<detail::Discovery_nodestorage> node_storage;
             
-            bool connect = ServiceSubscription_FilterService(service_types, this->filter,  RR_SHARED_PTR<detail::Discovery_nodestorage>(),
+            bool connect = ServiceSubscription_FilterService(service_types, this->filter,  node_storage,
                 info, filter_res_urls, filter_res, filter_node);
             
             if (!connect)

--- a/RobotRaconteurCore/src/Subscription.cpp
+++ b/RobotRaconteurCore/src/Subscription.cpp
@@ -1666,12 +1666,12 @@ void ServiceSubscription::UpdateServiceByType(const std::vector<std::string>& se
             
             if (!connect)
             {
-                ROBOTRACONTEUR_LOG_TRACE_COMPONENT(node, Subscription, -1, "Service filtered by UpdateServiceByType: " << c.NodeID.ToString() << "," << c.Name);
+                ROBOTRACONTEUR_LOG_TRACE_COMPONENT(node, Subscription, -1, "Service filtered by UpdateServiceByType: " << c->nodeid.ToString() << "," << c->nodename);
                 try
                 {                    
                     n->AsyncDisconnectService(c2, ServiceSubscription_close_handler);
                 }
-                catch (std::exception) {}
+                catch (std::exception&) {}
             }            
         }
         catch (std::exception& exp)

--- a/RobotRaconteurCore/src/Subscription.cpp
+++ b/RobotRaconteurCore/src/Subscription.cpp
@@ -3003,6 +3003,7 @@ void ServiceSubscription_custom_member_subscribers::SubscribePipe(const RR_SHARE
 
 ServiceSubscriptionFilterAttribute::ServiceSubscriptionFilterAttribute()
 {
+    UseRegex = false;
 }
 
 ServiceSubscriptionFilterAttribute::ServiceSubscriptionFilterAttribute(boost::string_ref value)
@@ -3122,10 +3123,7 @@ bool ServiceSubscriptionFilterAttribute::IsMatch(const RR_INTRUSIVE_PTR<RRMap<st
 
         std::string s2 = RRArrayToString(s);
 
-        if (IsMatch(e.first, s2))
-        {
-            return true;
-        }
+        return IsMatch(e.first, s2);
     }
 }
 
@@ -3157,14 +3155,14 @@ ServiceSubscriptionFilterAttributeGroup::ServiceSubscriptionFilterAttributeGroup
 ServiceSubscriptionFilterAttributeGroup::ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation, std::vector<ServiceSubscriptionFilterAttribute> attributes)
 {
     this->Operation = operation;
-    this->Attributes = attributes;
+    this->Attributes = RR_MOVE(attributes);
     this->SplitStringAttribute = true;
     this->SplitStringDelimiter = ',';
 }
 ServiceSubscriptionFilterAttributeGroup::ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation, std::vector<ServiceSubscriptionFilterAttributeGroup> groups)
 {
     this->Operation = operation;
-    this->Groups = groups;
+    this->Groups = RR_MOVE(groups);
     this->SplitStringAttribute = true;
     this->SplitStringDelimiter = ',';
 }

--- a/RobotRaconteurCore/src/Subscription.cpp
+++ b/RobotRaconteurCore/src/Subscription.cpp
@@ -106,10 +106,10 @@ void ServiceSubscription_retrytimer::timer_handler(RR_WEAK_PTR<ServiceSubscripti
 } // namespace detail
 static void ServiceSubscription_close_handler() {}
 
-ServiceSubscriptionFilter::ServiceSubscriptionFilter() { 
-    MaxConnections = 0; 
+ServiceSubscriptionFilter::ServiceSubscriptionFilter()
+{
+    MaxConnections = 0;
     AttributesMatchOperation = ServiceSubscriptionFilterAttributeGroupOperation_AND;
-    
 }
 
 ServiceSubscriptionClientID::ServiceSubscriptionClientID(const ::RobotRaconteur::NodeID& nodeid,
@@ -259,11 +259,11 @@ static bool ServiceSubscription_FilterService(const std::vector<std::string>& se
             }
         }
 
-        if(!filter->Attributes.empty())
+        if (!filter->Attributes.empty())
         {
-            typedef std::map<std::string,ServiceSubscriptionFilterAttributeGroup>::value_type attributes_map_type;
+            typedef std::map<std::string, ServiceSubscriptionFilterAttributeGroup>::value_type attributes_map_type;
             std::vector<bool> attr_matches;
-            BOOST_FOREACH(const attributes_map_type& e, filter->Attributes)
+            BOOST_FOREACH (const attributes_map_type& e, filter->Attributes)
             {
                 std::map<std::string, RR_INTRUSIVE_PTR<RRValue> >::const_iterator e2 = info.Attributes.find(e.first);
                 if (e2 == info.Attributes.end())
@@ -284,7 +284,7 @@ static bool ServiceSubscription_FilterService(const std::vector<std::string>& se
                 {
                     return false;
                 }
-                break;            
+                break;
             case ServiceSubscriptionFilterAttributeGroupOperation_NOR:
                 if (boost::range::find(attr_matches, true) != attr_matches.end())
                 {
@@ -1654,7 +1654,7 @@ void ServiceSubscription::UpdateServiceURL(const std::vector<std::string>& url, 
 }
 
 void ServiceSubscription::UpdateServiceByType(const std::vector<std::string>& service_types,
-        const RR_SHARED_PTR<ServiceSubscriptionFilter>& filter)
+                                              const RR_SHARED_PTR<ServiceSubscriptionFilter>& filter)
 {
     if (!active)
     {
@@ -1685,7 +1685,7 @@ void ServiceSubscription::UpdateServiceByType(const std::vector<std::string>& se
     }
 
     BOOST_FOREACH (RR_SHARED_PTR<detail::ServiceSubscription_client>& c, clients | boost::adaptors::map_values)
-    {        
+    {
         if (c->claimed.data())
         {
             continue;
@@ -1712,25 +1712,28 @@ void ServiceSubscription::UpdateServiceByType(const std::vector<std::string>& se
             std::string filter_res;
             RR_SHARED_PTR<ServiceSubscriptionFilterNode> filter_node;
             RR_SHARED_PTR<detail::Discovery_nodestorage> node_storage;
-            
-            bool connect = ServiceSubscription_FilterService(service_types, this->filter,  node_storage,
-                info, filter_res_urls, filter_res, filter_node);
-            
+
+            bool connect = ServiceSubscription_FilterService(service_types, this->filter, node_storage, info,
+                                                             filter_res_urls, filter_res, filter_node);
+
             if (!connect)
             {
-                ROBOTRACONTEUR_LOG_TRACE_COMPONENT(node, Subscription, -1, "Service filtered by UpdateServiceByType: " << c->nodeid.ToString() << "," << c->nodename);
+                ROBOTRACONTEUR_LOG_TRACE_COMPONENT(node, Subscription, -1,
+                                                   "Service filtered by UpdateServiceByType: " << c->nodeid.ToString()
+                                                                                               << "," << c->nodename);
                 try
-                {                    
+                {
                     n->AsyncDisconnectService(c2, ServiceSubscription_close_handler);
                 }
-                catch (std::exception&) {}
-            }            
+                catch (std::exception&)
+                {}
+            }
         }
         catch (std::exception& exp)
         {
-            ROBOTRACONTEUR_LOG_DEBUG_COMPONENT(node, Subscription, -1, "Error updating service by type: " << exp.what());
+            ROBOTRACONTEUR_LOG_DEBUG_COMPONENT(node, Subscription, -1,
+                                               "Error updating service by type: " << exp.what());
         }
-
     }
 
     RR_SHARED_PTR<detail::Discovery> d = parent.lock();
@@ -1738,8 +1741,9 @@ void ServiceSubscription::UpdateServiceByType(const std::vector<std::string>& se
     {
         return;
     }
-    RR_SHARED_PTR<Timer> t = n->CreateTimer(boost::posix_time::milliseconds(250), 
-        boost::bind(&detail::Discovery::DoUpdateAllDetectedServices, d, shared_from_this()));
+    RR_SHARED_PTR<Timer> t =
+        n->CreateTimer(boost::posix_time::milliseconds(250),
+                       boost::bind(&detail::Discovery::DoUpdateAllDetectedServices, d, shared_from_this()));
     t->Start();
 }
 
@@ -3001,10 +3005,7 @@ void ServiceSubscription_custom_member_subscribers::SubscribePipe(const RR_SHARE
 
 // ServiceSubscriptionFilterAttribute
 
-ServiceSubscriptionFilterAttribute::ServiceSubscriptionFilterAttribute()
-{
-    UseRegex = false;
-}
+ServiceSubscriptionFilterAttribute::ServiceSubscriptionFilterAttribute() { UseRegex = false; }
 
 ServiceSubscriptionFilterAttribute::ServiceSubscriptionFilterAttribute(boost::string_ref value)
 {
@@ -3028,7 +3029,8 @@ ServiceSubscriptionFilterAttribute::ServiceSubscriptionFilterAttribute(boost::st
     this->UseRegex = false;
 }
 
-ServiceSubscriptionFilterAttribute::ServiceSubscriptionFilterAttribute(boost::string_ref name, const boost::regex& value)
+ServiceSubscriptionFilterAttribute::ServiceSubscriptionFilterAttribute(boost::string_ref name,
+                                                                       const boost::regex& value)
 {
     this->Name = name.to_string();
     this->Value = "";
@@ -3123,7 +3125,7 @@ bool ServiceSubscriptionFilterAttribute::IsMatch(const RR_INTRUSIVE_PTR<RRMap<st
 
         std::string s2 = RRArrayToString(s);
 
-        if(IsMatch(e.first, s2))
+        if (IsMatch(e.first, s2))
         {
             return true;
         }
@@ -3150,20 +3152,25 @@ ServiceSubscriptionFilterAttributeGroup::ServiceSubscriptionFilterAttributeGroup
     this->SplitStringAttribute = true;
     this->SplitStringDelimiter = ',';
 }
-ServiceSubscriptionFilterAttributeGroup::ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation)
+ServiceSubscriptionFilterAttributeGroup::ServiceSubscriptionFilterAttributeGroup(
+    ServiceSubscriptionFilterAttributeGroupOperation operation)
 {
     this->Operation = operation;
     this->SplitStringAttribute = true;
     this->SplitStringDelimiter = ',';
 }
-ServiceSubscriptionFilterAttributeGroup::ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation, std::vector<ServiceSubscriptionFilterAttribute> attributes)
+ServiceSubscriptionFilterAttributeGroup::ServiceSubscriptionFilterAttributeGroup(
+    ServiceSubscriptionFilterAttributeGroupOperation operation,
+    std::vector<ServiceSubscriptionFilterAttribute> attributes)
 {
     this->Operation = operation;
     this->Attributes = RR_MOVE(attributes);
     this->SplitStringAttribute = true;
     this->SplitStringDelimiter = ',';
 }
-ServiceSubscriptionFilterAttributeGroup::ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation, std::vector<ServiceSubscriptionFilterAttributeGroup> groups)
+ServiceSubscriptionFilterAttributeGroup::ServiceSubscriptionFilterAttributeGroup(
+    ServiceSubscriptionFilterAttributeGroupOperation operation,
+    std::vector<ServiceSubscriptionFilterAttributeGroup> groups)
 {
     this->Operation = operation;
     this->Groups = RR_MOVE(groups);
@@ -3171,15 +3178,15 @@ ServiceSubscriptionFilterAttributeGroup::ServiceSubscriptionFilterAttributeGroup
     this->SplitStringDelimiter = ',';
 }
 
-template<typename T>
-static bool ServiceSubscriptionFilterAttributeGroup_do_filter(ServiceSubscriptionFilterAttributeGroupOperation operation, 
-const std::vector<ServiceSubscriptionFilterAttribute>&
-attributes, const std::vector<ServiceSubscriptionFilterAttributeGroup>& groups, const T& values)
+template <typename T>
+static bool ServiceSubscriptionFilterAttributeGroup_do_filter(
+    ServiceSubscriptionFilterAttributeGroupOperation operation,
+    const std::vector<ServiceSubscriptionFilterAttribute>& attributes,
+    const std::vector<ServiceSubscriptionFilterAttributeGroup>& groups, const T& values)
 {
     switch (operation)
     {
-    case ServiceSubscriptionFilterAttributeGroupOperation_OR:
-    {
+    case ServiceSubscriptionFilterAttributeGroupOperation_OR: {
         if (attributes.empty() && groups.empty())
         {
             return true;
@@ -3200,8 +3207,7 @@ attributes, const std::vector<ServiceSubscriptionFilterAttributeGroup>& groups, 
         }
         return false;
     }
-    case ServiceSubscriptionFilterAttributeGroupOperation_AND:
-    {
+    case ServiceSubscriptionFilterAttributeGroupOperation_AND: {
         if (attributes.empty() && groups.empty())
         {
             return true;
@@ -3222,16 +3228,15 @@ attributes, const std::vector<ServiceSubscriptionFilterAttributeGroup>& groups, 
         }
         return true;
     }
-    case ServiceSubscriptionFilterAttributeGroupOperation_NOR:
-    {
-        return !ServiceSubscriptionFilterAttributeGroup_do_filter(ServiceSubscriptionFilterAttributeGroupOperation_OR, attributes, groups, values);
+    case ServiceSubscriptionFilterAttributeGroupOperation_NOR: {
+        return !ServiceSubscriptionFilterAttributeGroup_do_filter(ServiceSubscriptionFilterAttributeGroupOperation_OR,
+                                                                  attributes, groups, values);
     }
-    case ServiceSubscriptionFilterAttributeGroupOperation_NAND:
-    {
-        return !ServiceSubscriptionFilterAttributeGroup_do_filter(ServiceSubscriptionFilterAttributeGroupOperation_AND, attributes, groups, values);
+    case ServiceSubscriptionFilterAttributeGroupOperation_NAND: {
+        return !ServiceSubscriptionFilterAttributeGroup_do_filter(ServiceSubscriptionFilterAttributeGroupOperation_AND,
+                                                                  attributes, groups, values);
     }
-    default:
-    {
+    default: {
         throw InvalidArgumentException("Invalid attribute filter operation");
     }
     }
@@ -3246,7 +3251,7 @@ bool ServiceSubscriptionFilterAttributeGroup::IsMatch(boost::string_ref value) c
         return IsMatch(value_v);
     }
     else
-    {   
+    {
         std::vector<std::string> value_v;
         boost::split(value_v, value, boost::is_any_of(","));
         return IsMatch(value_v);
@@ -3277,7 +3282,8 @@ bool ServiceSubscriptionFilterAttributeGroup::IsMatch(const std::map<std::string
 {
     return ServiceSubscriptionFilterAttributeGroup_do_filter(Operation, Attributes, Groups, values);
 }
-bool ServiceSubscriptionFilterAttributeGroup::IsMatch(const RR_INTRUSIVE_PTR<RRMap<std::string, RRValue> >& values) const
+bool ServiceSubscriptionFilterAttributeGroup::IsMatch(
+    const RR_INTRUSIVE_PTR<RRMap<std::string, RRValue> >& values) const
 {
     return ServiceSubscriptionFilterAttributeGroup_do_filter(Operation, Attributes, Groups, values);
 }
@@ -3298,10 +3304,10 @@ bool ServiceSubscriptionFilterAttributeGroup::IsMatch(const RR_INTRUSIVE_PTR<RRV
     RR_INTRUSIVE_PTR<RRList<RRValue> > a1 = RR_DYNAMIC_POINTER_CAST<RRList<RRValue> >(values);
     if (a1)
     {
-       return IsMatch(a1);
+        return IsMatch(a1);
     }
 
-    RR_INTRUSIVE_PTR<RRMap<std::string,RRValue> > a2 = RR_DYNAMIC_POINTER_CAST<RRMap<std::string,RRValue> >(values);
+    RR_INTRUSIVE_PTR<RRMap<std::string, RRValue> > a2 = RR_DYNAMIC_POINTER_CAST<RRMap<std::string, RRValue> >(values);
     if (a2)
     {
         return IsMatch(a2);
@@ -3315,7 +3321,8 @@ ServiceSubscriptionFilterAttribute CreateServiceSubscriptionFilterAttributeRegex
     boost::regex r(regex_value.begin(), regex_value.end());
     return ServiceSubscriptionFilterAttribute(r);
 }
-ServiceSubscriptionFilterAttribute CreateServiceSubscriptionFilterAttributeRegex(boost::string_ref name, boost::string_ref regex_value)
+ServiceSubscriptionFilterAttribute CreateServiceSubscriptionFilterAttributeRegex(boost::string_ref name,
+                                                                                 boost::string_ref regex_value)
 {
     boost::regex r(regex_value.begin(), regex_value.end());
     return ServiceSubscriptionFilterAttribute(name, r);

--- a/RobotRaconteurCore/src/Subscription.cpp
+++ b/RobotRaconteurCore/src/Subscription.cpp
@@ -3030,7 +3030,7 @@ ServiceSubscriptionFilterAttribute::ServiceSubscriptionFilterAttribute(boost::st
     this->UseRegex = false;
 }
 
-ServiceSubscriptionFilterAttribute::ServiceSubscriptionFilterAttribute(boost::string_ref name, boost::regex value)
+ServiceSubscriptionFilterAttribute::ServiceSubscriptionFilterAttribute(boost::string_ref name, const boost::regex& value)
 {
     this->Name = name.to_string();
     this->Value = "";

--- a/RobotRaconteurCore/src/Subscription_private.h
+++ b/RobotRaconteurCore/src/Subscription_private.h
@@ -45,6 +45,8 @@ class ServiceSubscription_client : private boost::noncopyable
 
     boost::initialized<bool> claimed;
 
+    boost::initialized<bool> erase;
+
     ServiceSubscription_client();
 };
 

--- a/RobotRaconteurJava/NodeIDJava.i
+++ b/RobotRaconteurJava/NodeIDJava.i
@@ -65,6 +65,7 @@ public:
 	%javamethodmodifiers NodeID(std::vector<uint8_t> id) "private";
 	//NodeID(std::vector<uint8_t> id);
 	NodeID(const std::string& id);
+	NodeID(const NodeID& id);
 
 	
 	

--- a/RobotRaconteurJava/src/com/robotraconteur/ServiceSubscriptionClientID.java
+++ b/RobotRaconteurJava/src/com/robotraconteur/ServiceSubscriptionClientID.java
@@ -7,13 +7,13 @@ public class ServiceSubscriptionClientID
 
     public ServiceSubscriptionClientID(NodeID node_id, String service_name)
     {
-        this.NodeID = node_id;
+        this.NodeID = new NodeID(node_id);
         this.ServiceName = service_name;
     }
 
     ServiceSubscriptionClientID(WrappedServiceSubscriptionClientID id1)
     {
-        this.NodeID = id1.getNodeID();
+        this.NodeID = new NodeID(id1.getNodeID());
         this.ServiceName = id1.getServiceName();
     }
 

--- a/RobotRaconteurMex/RobotRaconteurMex.cpp
+++ b/RobotRaconteurMex/RobotRaconteurMex.cpp
@@ -8759,7 +8759,7 @@ static boost::shared_ptr<ServiceSubscriptionFilter> SubscribeService_LoadFilter(
         {
             if (std::string(mxGetClassName(attributes1)) != "containers.Map")
                 throw DataTypeException("Expected filter attributes to be containers.Map");
-            
+
             mxArray* keys = NULL;
             mxArray* values = NULL;
             mxArray* pm2 = (mxArray*)attributes1;
@@ -8792,8 +8792,9 @@ static boost::shared_ptr<ServiceSubscriptionFilter> SubscribeService_LoadFilter(
                 else if (mxIsCell(data))
                 {
                     std::vector<std::string> attrib_values;
-                    mxToVectorString(data, attrib_values, "Invalid filter.Attributes specified for SubscribeServiceByType");
-                    BOOST_FOREACH(std::string& s, attrib_values)
+                    mxToVectorString(data, attrib_values,
+                                     "Invalid filter.Attributes specified for SubscribeServiceByType");
+                    BOOST_FOREACH (std::string& s, attrib_values)
                     {
                         attribute_group.Attributes.push_back(ServiceSubscriptionFilterAttribute(s));
                     }
@@ -8807,13 +8808,15 @@ static boost::shared_ptr<ServiceSubscriptionFilter> SubscribeService_LoadFilter(
                         throw DataTypeException("Invalid filter.Attributes specified for SubscribeServiceByType");
                     if (mxIsChar(group_attr))
                     {
-                        attribute_group.Attributes.push_back(ServiceSubscriptionFilterAttribute(mxToString(group_attr)));
+                        attribute_group.Attributes.push_back(
+                            ServiceSubscriptionFilterAttribute(mxToString(group_attr)));
                     }
                     else if (mxIsCell(group_attr))
                     {
                         std::vector<std::string> attrib_values;
-                        mxToVectorString(group_attr, attrib_values, "Invalid filter.Attributes specified for SubscribeServiceByType");
-                        BOOST_FOREACH(std::string& s, attrib_values)
+                        mxToVectorString(group_attr, attrib_values,
+                                         "Invalid filter.Attributes specified for SubscribeServiceByType");
+                        BOOST_FOREACH (std::string& s, attrib_values)
                         {
                             attribute_group.Attributes.push_back(ServiceSubscriptionFilterAttribute(s));
                         }
@@ -8854,11 +8857,8 @@ static boost::shared_ptr<ServiceSubscriptionFilter> SubscribeService_LoadFilter(
                     throw DataTypeException("Invalid filter.Attributes specified for SubscribeServiceByType");
                 }
 
-                filter2->Attributes.insert(std::make_pair(attribute_name,attribute_group));
-
+                filter2->Attributes.insert(std::make_pair(attribute_name, attribute_group));
             }
-
-            
         }
 
         if (mxArray* attributes_op1 = ::mxGetField(filter, 0, "AttributesMatchOperator"))
@@ -8871,7 +8871,7 @@ static boost::shared_ptr<ServiceSubscriptionFilter> SubscribeService_LoadFilter(
             }
             else if (attributes_op == "or")
             {
-                filter2->AttributesMatchOperation= ServiceSubscriptionFilterAttributeGroupOperation_AND;
+                filter2->AttributesMatchOperation = ServiceSubscriptionFilterAttributeGroupOperation_AND;
             }
             else if (attributes_op == "nand")
             {
@@ -8879,11 +8879,12 @@ static boost::shared_ptr<ServiceSubscriptionFilter> SubscribeService_LoadFilter(
             }
             else if (attributes_op == "nor")
             {
-                filter2->AttributesMatchOperation= ServiceSubscriptionFilterAttributeGroupOperation_NAND;
+                filter2->AttributesMatchOperation = ServiceSubscriptionFilterAttributeGroupOperation_NAND;
             }
             else
             {
-                throw InvalidArgumentException("Invalid filter.AttributesOperator specified for SubscribeServiceByType");
+                throw InvalidArgumentException(
+                    "Invalid filter.AttributesOperator specified for SubscribeServiceByType");
             }
         }
 

--- a/RobotRaconteurNET/NodeIDNET.i
+++ b/RobotRaconteurNET/NodeIDNET.i
@@ -66,6 +66,7 @@ public:
 	
 	//NodeID(std::boost<uint8_t,16> id);
 	NodeID(const std::string& id);
+	NodeID(const NodeID& id);
 
 	
 	

--- a/RobotRaconteurNET/RobotRaconteurNET.xml.in
+++ b/RobotRaconteurNET/RobotRaconteurNET.xml.in
@@ -4065,6 +4065,71 @@
       </remarks>
     </member>
 
+    <MemberName name="T:RobotRaconteur.ServiceSubscriptionFilterAttribute">
+      <summary>Subscription filter attribute for use with ServiceSubscriptionFilter</summary>
+    </MemberName>
+
+    <MemberName name="M:RobotRaconteur.ServiceSubscriptionFilterAttribute.#ctor">
+      <summary>Construct a new ServiceSubscriptionFilterAttribute</summary>
+    </MemberName>
+
+    <MemberName name="P:RobotRaconteur.ServiceSubscriptionFilterAttribute.Name">
+      <summary>The attribute name. Empty for no name</summary>
+    </MemberName>
+
+    <MemberName name="P:RobotRaconteur.ServiceSubscriptionFilterAttribute.Value">
+      <summary>The string value of the attribute</summary>
+    </MemberName>
+
+    <MemberName name="T:RobotRaconteur.ServiceSubscriptionFilterAttributeGroupOperation">
+      <summary>Subscription filter attribute group for use with ServiceSubscriptionFilter</summary>
+    </MemberName>
+
+    <MemberName name="F:RobotRaconteur.ServiceSubscriptionFilterAttributeGroupOperation.OR">
+      <summary>OR Operation</summary>
+    </MemberName>
+  
+    <MemberName name="F:RobotRaconteur.ServiceSubscriptionFilterAttributeGroupOperation.AND">
+      <summary>AND Operation</summary>
+    </MemberName>
+
+    <MemberName name="F:RobotRaconteur.ServiceSubscriptionFilterAttributeGroupOperation.NOR">
+      <summary>NOR Operation</summary>
+    </MemberName>
+
+    <MemberName name="F:RobotRaconteur.ServiceSubscriptionFilterAttributeGroupOperation.NAND">
+      <summary>NAND Operation</summary>
+    </MemberName>
+
+    <MemberName name="T:RobotRaconteur.ServiceSubscriptionFilterAttributeGroup">
+      <summary>Subscription filter for use with ServiceSubscription</summary>
+    </MemberName>
+
+    <MemberName name="M:RobotRaconteur.ServiceSubscriptionFilterAttributeGroup.#ctor">
+      <summary>Construct a new ServiceSubscriptionFilterAttributeGroup</summary>
+    </MemberName>
+
+    <MemberName name="P:RobotRaconteur.ServiceSubscriptionFilterAttributeGroup.Attributes">
+      <summary>The attributes in the group</summary>
+    </MemberName>
+
+    <MemberName name="P:RobotRaconteur.ServiceSubscriptionFilterAttributeGroup.Groups">
+      <summary>The nested groups in the group</summary>
+    </MemberName>
+
+    <MemberName name="P:RobotRaconteur.ServiceSubscriptionFilterAttributeGroup.Operation">
+      <summary>The operation to use for matching the attributes and groups</summary>
+    </MemberName>
+
+    <MemberName name="P:RobotRaconteur.ServiceSubscriptionFilterAttributeGroup.SplitStringAttribute">
+      <summary>True if string attributes will be split into a list with delimiter (default ",")</summary>
+    </MemberName>
+
+    <MemberName name="P:RobotRaconteur.ServiceSubscriptionFilterAttributeGroup.SplitStringDelimiter">
+      <summary>Delimiter to use to split string attributes (default ",")</summary>
+    </MemberName>
+    
+
     <!-- BEGIN GENERATED_MEMBERS -->
     <!-- GENERATED_MEMBERS -->
     <!-- END GENERATED_MEMBERS -->

--- a/RobotRaconteurNET/RobotRaconteurNET/Subscription.cs
+++ b/RobotRaconteurNET/RobotRaconteurNET/Subscription.cs
@@ -54,13 +54,13 @@ public partial class ServiceSubscriptionClientID
     /// <param name="service_name">The Service Name</param>
     public ServiceSubscriptionClientID(NodeID node_id, string service_name)
     {
-        this.NodeID = node_id;
+        this.NodeID = new NodeID(node_id);
         this.ServiceName = service_name;
     }
 
     internal ServiceSubscriptionClientID(WrappedServiceSubscriptionClientID id1)
     {
-        this.NodeID = id1.NodeID;
+        this.NodeID = new NodeID(id1.NodeID);
         this.ServiceName = id1.ServiceName;
     }
 

--- a/RobotRaconteurNET/RobotRaconteurNET/Subscription.cs
+++ b/RobotRaconteurNET/RobotRaconteurNET/Subscription.cs
@@ -161,6 +161,16 @@ public class ServiceSubscriptionFilter
     /// <remarks>None</remarks>
     public string[] TransportSchemes;
     /// <summary>
+    /// Attributes to match
+    /// </summary>
+    /// <remarks>None</remarks>
+    public Dictionary<string,ServiceSubscriptionFilterAttributeGroup> Attributes;
+    /// <summary>
+    /// Operation to use to match attributes. Defaults to AND 
+    /// </summary>
+    public ServiceSubscriptionFilterAttributeGroupOperation AttributesMatchOperation;
+
+    /// <summary>
     /// A user specified predicate function. If nullptr, the predicate is not checked.
     /// </summary>
     /// <remarks>None</remarks>
@@ -778,6 +788,17 @@ public class ServiceSubscription
         }
     }
 
+     public void UpdateServiceByType(string[] service_types, ServiceSubscriptionFilter filter = null)
+    {
+        var filter2 = RobotRaconteurNode.s.SubscribeService_LoadFilter(filter);
+
+        var service_types2 = new vectorstring();
+        foreach (string s in service_types)
+            service_types2.Add(s);
+
+        this._subscription.UpdateServiceByType(service_types2, filter2);
+    }
+
     /// <summary>
     /// Update the service connection URL
     /// </summary>
@@ -1356,7 +1377,7 @@ public partial class RobotRaconteurNode
         }
     }
 
-    private WrappedServiceSubscriptionFilter SubscribeService_LoadFilter(ServiceSubscriptionFilter filter)
+    internal WrappedServiceSubscriptionFilter SubscribeService_LoadFilter(ServiceSubscriptionFilter filter)
     {
         WrappedServiceSubscriptionFilter filter2 = null;
         if (filter != null)
@@ -1368,6 +1389,16 @@ public partial class RobotRaconteurNode
             if (filter.TransportSchemes != null)
                 foreach (string s in filter.TransportSchemes)
                     filter2.TransportSchemes.Add(s);
+            if (filter.Attributes != null)
+            {
+                foreach (var a in filter.Attributes)
+                {
+                    if (a.Value == null)
+                        continue;
+                    filter2.Attributes[a.Key] = a.Value;
+                }
+            }
+            filter2.AttributesMatchOperation = filter.AttributesMatchOperation;
             filter2.MaxConnections = filter.MaxConnections;
             if (filter.Nodes != null)
             {

--- a/RobotRaconteurNET/RobotRaconteurNET/Subscription.cs
+++ b/RobotRaconteurNET/RobotRaconteurNET/Subscription.cs
@@ -164,9 +164,9 @@ public class ServiceSubscriptionFilter
     /// Attributes to match
     /// </summary>
     /// <remarks>None</remarks>
-    public Dictionary<string,ServiceSubscriptionFilterAttributeGroup> Attributes;
+    public Dictionary<string, ServiceSubscriptionFilterAttributeGroup> Attributes;
     /// <summary>
-    /// Operation to use to match attributes. Defaults to AND 
+    /// Operation to use to match attributes. Defaults to AND
     /// </summary>
     public ServiceSubscriptionFilterAttributeGroupOperation AttributesMatchOperation;
 
@@ -788,7 +788,7 @@ public class ServiceSubscription
         }
     }
 
-     public void UpdateServiceByType(string[] service_types, ServiceSubscriptionFilter filter = null)
+    public void UpdateServiceByType(string[] service_types, ServiceSubscriptionFilter filter = null)
     {
         var filter2 = RobotRaconteurNode.s.SubscribeService_LoadFilter(filter);
 

--- a/RobotRaconteurPython/PythonDocstring.i
+++ b/RobotRaconteurPython/PythonDocstring.i
@@ -818,6 +818,7 @@ Close the transport. Done automatically by node shutdown.
 """
 
 %feature("docstring") RobotRaconteur::IntraTransport::StartServer() """Start the server to listen for incoming client connections"""
+%feature("docstring") RobotRaconteur::IntraTransport::StartClient() """Start the transport as a client"""
 
 
 %feature("docstring") RobotRaconteur::LocalTransport """
@@ -1684,3 +1685,42 @@ End the update loop step
 
 Use BroadcastDownsamplerStep for automatic stepping
 """
+%feature("docstring") ServiceSubscriptionFilterAttributeGroupOperation_OR "OR operation"
+%feature("docstring") ServiceSubscriptionFilterAttributeGroupOperation_AND "AND operation"
+%feature("docstring") ServiceSubscriptionFilterAttributeGroupOperation_NOR "NOR operation. Also used for NOT"
+%feature("docstring") ServiceSubscriptionFilterAttributeGroupOperation_NAND "NAND operation"
+
+%feature("docstring") RobotRaconteur::ServiceSubscriptionFilterAttribute """
+ServiceSubscriptionFilterAttribute()
+
+Subscription filter attribute for use with ServiceSubscriptionFilter
+"""
+
+%feature("docstring") RobotRaconteur::ServiceSubscriptionFilterAttribute::Name """(str) The attribute name. Empty for no name"""
+%feature("docstring") RobotRaconteur::ServiceSubscriptionFilterAttribute::Value """(str) The string value for the attribute"""
+
+%feature("docstring") RobotRaconteur::CreateServiceSubscriptionFilterAttributeRegex(const std::string& regex_value) """
+
+Create a ServiceSubscriptionFilterAttribute from a regex string
+
+:param regex_value: The regex string
+:type regex_value: str
+:return: The ServiceSubscriptionFilterAttribute
+:rtype: RobotRaconteur.ServiceSubscriptionFilterAttribute
+"""
+
+%feature("docstring") RobotRaconteur::ServiceSubscriptionFilterAttributeGroup """
+ServiceSubscriptionFilterAttributeGroup()
+
+Subscription filter attribute group for use with ServiceSubscriptionFilter
+
+Used to combine multiple ServiceSubscriptionFilterAttribute objects for comparison using
+AND, OR, NOR, or NAND logic. Other groups can be nested, to allow for complex comparisons.
+"""
+
+%feature("docstring") RobotRaconteur::ServiceSubscriptionFilterAttributeGroup::Operation """(RobotRaconteur.ServiceSubscriptionFilterAttributeGroupOperation) The operation to use to combine the attributes"""
+%feature("docstring") RobotRaconteur::ServiceSubscriptionFilterAttributeGroup::Attributes """(list) The list of attributes in the group"""
+%feature("docstring") RobotRaconteur::ServiceSubscriptionFilterAttributeGroup::Groups """(list) The nested groups in the group"""
+%feature("docstring") RobotRaconteur::ServiceSubscriptionFilterAttributeGroup::SplitStringAttribute """(bool) True if string attributes will be split into a list with delimiter (default ',')"""
+%feature("docstring") RobotRaconteur::ServiceSubscriptionFilterAttributeGroup::SplitStringDelimiter """(str) The delimiter to use for splitting string attributes (default ',')"""
+

--- a/RobotRaconteurPython/RobotRaconteurPythonUtil.py
+++ b/RobotRaconteurPython/RobotRaconteurPythonUtil.py
@@ -4463,7 +4463,35 @@ class ServiceSubscription(object):
                 credentials, "varvalue{string}", None, self._subscription.GetNode()).GetData()
         self._subscription.UpdateServiceURL(
             url, username, credentials, "", close_connected)
+    
+    def UpdateServiceByType(self, service_types, filter_=None):
+        """
+        Update the service types and filter
 
+        :param service_types: The new service types to use to connect to service
+        :type service_types: Union[str,List[str]]
+        :param filter_: Optional filter to use to connect to service
+        :type filter_: Union[str,RobotRaconteurPython.ServiceSubscriptionFilter]
+        """
+
+        node = self._subscription.GetNode()
+        filter2 = _SubscribeService_LoadFilter(node, filter_)
+
+        service_types2 = RobotRaconteurPython.vectorstring()
+        if (sys.version_info > (3, 0)):
+            if (isinstance(service_types, str)):
+                service_types2.append(service_types)
+            else:
+                for s in service_types:
+                    service_types2.append(s)
+        else:
+            if (isinstance(service_types, (str, unicode))):
+                service_types2.append(service_types)
+            else:
+                for s in service_types:
+                    service_types2.append(s)
+
+        self._subscription.UpdateServiceByType(service_types2, filter2)
 
 class WrappedWireSubscriptionDirectorPython(RobotRaconteurPython.WrappedWireSubscriptionDirector):
     def __init__(self, subscription):
@@ -4946,7 +4974,6 @@ def SubscribeServiceByType(node, service_types, filter_=None):
     sub1 = RobotRaconteurPython.WrappedSubscribeServiceByType(
         node, service_types2, filter2)
     return ServiceSubscription(sub1)
-
 
 def SubscribeService(node, *args):
     args2 = list(args)

--- a/RobotRaconteurPython/RobotRaconteurPythonUtil.py
+++ b/RobotRaconteurPython/RobotRaconteurPythonUtil.py
@@ -3888,7 +3888,7 @@ class ServiceSubscriptionClientID(object):
         """(str) The ServiceName of the connected service"""
 
         if (len(args) == 1):
-            self.NodeID = args[0].NodeID
+            self.NodeID = RobotRaconteurPython.NodeID(args[0].NodeID)
             self.ServiceName = args[0].ServiceName
         elif (len(args) == 2):
             self.NodeID = args[0]
@@ -3904,6 +3904,9 @@ class ServiceSubscriptionClientID(object):
 
     def __hash__(self):
         return hash((str(self.NodeID), self.ServiceName))
+    
+    def __str__(self):
+        return str(self.NodeID) + "," + self.ServiceName
 
 
 class ServiceSubscriptionFilterNode(object):

--- a/RobotRaconteurPython/RobotRaconteurPythonUtil.py
+++ b/RobotRaconteurPython/RobotRaconteurPythonUtil.py
@@ -3940,7 +3940,7 @@ class ServiceSubscriptionFilter(object):
     the filter before connecting.
     """
     __slots__ = ["Nodes", "ServiceNames",
-                 "TransportSchemes", "Predicate", "MaxConnections"]
+                 "TransportSchemes", "Predicate", "Attributes", "AttributesMatchOperation", "MaxConnections"]
 
     def __init__(self):
         self.Nodes = []
@@ -3949,6 +3949,11 @@ class ServiceSubscriptionFilter(object):
         """(List[str])  List of service names that should be connected. Empty means match any service name."""
         self.TransportSchemes = []
         """(List[str]) List of transport schemes. Empty means match any transport scheme."""
+        self.Attributes = dict()
+        """(Dict[str,RobotRaconteur.ServiceSubscriptionFilterAttributeGroup] Attributes to match)"""
+        self.AttributesMatchOperation = RobotRaconteurPython.ServiceSubscriptionFilterAttributeGroupOperation_AND
+        """(RobotRaconteur.ServiceSubscriptionFilterAttributeGroupOperation) The operation to use when matching attributes. 
+        Default is AND. Can be OR, AND, NOR, and NAND."""
         self.Predicate = None
         """(Callable[[RobotRaconteur.ServiceInfo2],bool]) A user specified predicate function. If nullptr, the predicate is not checked."""
         self.MaxConnections = 1000000
@@ -4902,7 +4907,10 @@ def _SubscribeService_LoadFilter(node, filter_):
             for s in filter_.TransportSchemes:
                 filter2.TransportSchemes.append(s)
         filter2.MaxConnections = filter_.MaxConnections
-
+        if (filter_.Attributes is not None):
+            for n,v in filter_.Attributes.items():
+                filter2.Attributes[n] = v
+        filter_.AttributesMatchOperation = filter_.AttributesMatchOperation
         if (filter_.Nodes is not None):
             nodes2 = RobotRaconteurPython.vectorptr_wrappedservicesubscriptionnode()
             for n1 in filter_.Nodes:

--- a/RobotRaconteurPython/RobotRaconteurPythonUtil.py
+++ b/RobotRaconteurPython/RobotRaconteurPythonUtil.py
@@ -3904,7 +3904,7 @@ class ServiceSubscriptionClientID(object):
 
     def __hash__(self):
         return hash((str(self.NodeID), self.ServiceName))
-    
+
     def __str__(self):
         return str(self.NodeID) + "," + self.ServiceName
 
@@ -4471,7 +4471,7 @@ class ServiceSubscription(object):
                 credentials, "varvalue{string}", None, self._subscription.GetNode()).GetData()
         self._subscription.UpdateServiceURL(
             url, username, credentials, "", close_connected)
-    
+
     def UpdateServiceByType(self, service_types, filter_=None):
         """
         Update the service types and filter
@@ -4500,6 +4500,7 @@ class ServiceSubscription(object):
                     service_types2.append(s)
 
         self._subscription.UpdateServiceByType(service_types2, filter2)
+
 
 class WrappedWireSubscriptionDirectorPython(RobotRaconteurPython.WrappedWireSubscriptionDirector):
     def __init__(self, subscription):
@@ -4911,7 +4912,7 @@ def _SubscribeService_LoadFilter(node, filter_):
                 filter2.TransportSchemes.append(s)
         filter2.MaxConnections = filter_.MaxConnections
         if (filter_.Attributes is not None):
-            for n,v in filter_.Attributes.items():
+            for n, v in filter_.Attributes.items():
                 filter2.Attributes[n] = v
         filter_.AttributesMatchOperation = filter_.AttributesMatchOperation
         if (filter_.Nodes is not None):
@@ -4985,6 +4986,7 @@ def SubscribeServiceByType(node, service_types, filter_=None):
     sub1 = RobotRaconteurPython.WrappedSubscribeServiceByType(
         node, service_types2, filter2)
     return ServiceSubscription(sub1)
+
 
 def SubscribeService(node, *args):
     args2 = list(args)

--- a/SWIG/IntraTransport.i
+++ b/SWIG/IntraTransport.i
@@ -27,6 +27,7 @@ public:
 	virtual std::vector<std::string> GetServerListenUrls();
 	void Close();
 
+	void StartClient();
 	void StartServer();
 };
 

--- a/SWIG/NodeID.i
+++ b/SWIG/NodeID.i
@@ -31,6 +31,7 @@ public:
 	
 	NodeID(boost::array<uint8_t,16> id);
 	NodeID(const std::string& id);
+	NodeID(const NodeID& id);
 
 	boost::array<uint8_t,16> ToByteArray();
 };

--- a/SWIG/RobotRaconteurWrapped.cpp
+++ b/SWIG/RobotRaconteurWrapped.cpp
@@ -4332,6 +4332,8 @@ static RR_SHARED_PTR<ServiceSubscriptionFilter> WrappedSubscribeService_LoadFilt
         filter2 = RR_MAKE_SHARED<ServiceSubscriptionFilter>();
         filter2->ServiceNames = filter->ServiceNames;
         filter2->TransportSchemes = filter->TransportSchemes;
+        filter2->Attributes = filter->Attributes;
+        filter2->AttributesMatchOperation = filter->AttributesMatchOperation;
         filter2->MaxConnections = filter->MaxConnections;
         BOOST_FOREACH (RR_SHARED_PTR<WrappedServiceSubscriptionFilterNode>& n, filter->Nodes)
         {

--- a/SWIG/RobotRaconteurWrapped.cpp
+++ b/SWIG/RobotRaconteurWrapped.cpp
@@ -4070,7 +4070,19 @@ void WrappedServiceSubscription::UpdateServiceURL(const std::vector<std::string>
 void WrappedServiceSubscription::UpdateServiceURL(const std::string& url, const std::string& username,
                                                   const boost::intrusive_ptr<MessageElementData>& credentials,
                                                   const std::string& objecttype, bool close_connected)
-{}
+{
+    std::vector<std::string> url2;
+    url2.push_back(url);
+    UpdateServiceURL(url2, username, credentials, objecttype, close_connected);
+}
+
+void WrappedServiceSubscription::UpdateServiceByType(const std::vector<std::string>& service_types,
+        const RR_SHARED_PTR<WrappedServiceSubscriptionFilter>& filter)
+{
+    RR_SHARED_PTR<RobotRaconteurNode> node = GetNode();
+    RR_SHARED_PTR<ServiceSubscriptionFilter> filter2 = WrappedSubscribeService_LoadFilter(node, filter);
+    subscription->UpdateServiceByType(service_types, filter2);
+}
 
 WrappedWireSubscription::WrappedWireSubscription(const RR_SHARED_PTR<ServiceSubscription>& parent,
                                                  const std::string& membername, const std::string& servicepath)

--- a/SWIG/RobotRaconteurWrapped.cpp
+++ b/SWIG/RobotRaconteurWrapped.cpp
@@ -4077,7 +4077,7 @@ void WrappedServiceSubscription::UpdateServiceURL(const std::string& url, const 
 }
 
 void WrappedServiceSubscription::UpdateServiceByType(const std::vector<std::string>& service_types,
-        const RR_SHARED_PTR<WrappedServiceSubscriptionFilter>& filter)
+                                                     const RR_SHARED_PTR<WrappedServiceSubscriptionFilter>& filter)
 {
     RR_SHARED_PTR<RobotRaconteurNode> node = GetNode();
     RR_SHARED_PTR<ServiceSubscriptionFilter> filter2 = WrappedSubscribeService_LoadFilter(node, filter);

--- a/SWIG/RobotRaconteurWrapped.h
+++ b/SWIG/RobotRaconteurWrapped.h
@@ -1843,7 +1843,7 @@ class WrappedServiceSubscriptionFilter
     std::vector<RR_SHARED_PTR<WrappedServiceSubscriptionFilterNode> > Nodes;
     std::vector<std::string> ServiceNames;
     std::vector<std::string> TransportSchemes;
-    std::map<std::string,ServiceSubscriptionFilterAttributeGroup> Attributes;
+    std::map<std::string, ServiceSubscriptionFilterAttributeGroup> Attributes;
     ServiceSubscriptionFilterAttributeGroupOperation AttributesMatchOperation;
     RR_SHARED_PTR<WrappedServiceSubscriptionFilterPredicateDirector> Predicate;
     void SetRRPredicateDirector(WrappedServiceSubscriptionFilterPredicateDirector* director, int32_t id);
@@ -1985,7 +1985,8 @@ class WrappedServiceSubscription : public RR_ENABLE_SHARED_FROM_THIS<WrappedServ
         const std::string& objecttype = "", bool close_connected = false);
 
     void UpdateServiceByType(const std::vector<std::string>& service_types,
-        const RR_SHARED_PTR<WrappedServiceSubscriptionFilter>& filter = RR_SHARED_PTR<WrappedServiceSubscriptionFilter>());
+                             const RR_SHARED_PTR<WrappedServiceSubscriptionFilter>& filter =
+                                 RR_SHARED_PTR<WrappedServiceSubscriptionFilter>());
 
   protected:
     RR_SHARED_PTR<ServiceSubscription> subscription;

--- a/SWIG/RobotRaconteurWrapped.h
+++ b/SWIG/RobotRaconteurWrapped.h
@@ -1982,6 +1982,9 @@ class WrappedServiceSubscription : public RR_ENABLE_SHARED_FROM_THIS<WrappedServ
         const boost::intrusive_ptr<MessageElementData>& credentials = boost::intrusive_ptr<MessageElementData>(),
         const std::string& objecttype = "", bool close_connected = false);
 
+    void UpdateServiceByType(const std::vector<std::string>& service_types,
+        const RR_SHARED_PTR<WrappedServiceSubscriptionFilter>& filter = RR_SHARED_PTR<WrappedServiceSubscriptionFilter>());
+
   protected:
     RR_SHARED_PTR<ServiceSubscription> subscription;
     RR_SHARED_PTR<WrappedServiceSubscriptionDirector> RR_Director;
@@ -2124,6 +2127,9 @@ RR_SHARED_PTR<WrappedServiceSubscription> WrappedSubscribeService(
     const RR_SHARED_PTR<RobotRaconteurNode>& node, const std::string& url, const std::string& username = "",
     const boost::intrusive_ptr<MessageElementData>& credentials = boost::intrusive_ptr<MessageElementData>(),
     const std::string& objecttype = "");
+
+static RR_SHARED_PTR<ServiceSubscriptionFilter> WrappedSubscribeService_LoadFilter(
+    const RR_SHARED_PTR<RobotRaconteurNode>& node, const RR_SHARED_PTR<WrappedServiceSubscriptionFilter>& filter);
 
 class UserLogRecordHandlerDirector
 {

--- a/SWIG/RobotRaconteurWrapped.h
+++ b/SWIG/RobotRaconteurWrapped.h
@@ -1843,6 +1843,8 @@ class WrappedServiceSubscriptionFilter
     std::vector<RR_SHARED_PTR<WrappedServiceSubscriptionFilterNode> > Nodes;
     std::vector<std::string> ServiceNames;
     std::vector<std::string> TransportSchemes;
+    std::map<std::string,ServiceSubscriptionFilterAttributeGroup> Attributes;
+    ServiceSubscriptionFilterAttributeGroupOperation AttributesMatchOperation;
     RR_SHARED_PTR<WrappedServiceSubscriptionFilterPredicateDirector> Predicate;
     void SetRRPredicateDirector(WrappedServiceSubscriptionFilterPredicateDirector* director, int32_t id);
     uint32_t MaxConnections;

--- a/SWIG/Subscription.i
+++ b/SWIG/Subscription.i
@@ -42,6 +42,68 @@ namespace RobotRaconteur
 	class TimeSpec;
 	class ServiceInfo2;
 
+	class ServiceSubscriptionFilterAttribute
+	{
+		public:
+
+			std::string Name;
+			std::string Value;
+			// boost::regex ValueRegex;
+			bool UseRegex;
+			
+			ServiceSubscriptionFilterAttribute(const std::string& value);
+			ServiceSubscriptionFilterAttribute(const std::string& name, const std::string& value);
+
+			bool IsMatch(const std::string& value) const;
+			bool IsMatch(const std::string& name, const std::string& value) const;
+			bool IsMatch(const std::vector<std::string>& values) const;
+			bool IsMatch(const std::map<std::string, std::string>& values) const;
+	};
+
+	ServiceSubscriptionFilterAttribute CreateServiceSubscriptionFilterAttributeRegex(const std::string& regex_value);
+	ServiceSubscriptionFilterAttribute CreateServiceSubscriptionFilterAttributeRegex(const std::string& name, const std::string& regex_value);
+}
+
+%template(vector_subscriptionattribute)  std::vector<RobotRaconteur::ServiceSubscriptionFilterAttribute>;
+%template(map_subscriptionattribute)  std::map<std::string,RobotRaconteur::ServiceSubscriptionFilterAttribute>;
+
+namespace RobotRaconteur 
+{
+
+	enum ServiceSubscriptionFilterAttributeGroupOperation
+	{
+		ServiceSubscriptionFilterAttributeGroupOperation_OR,
+		ServiceSubscriptionFilterAttributeGroupOperation_AND,
+		ServiceSubscriptionFilterAttributeGroupOperation_NOR,
+		ServiceSubscriptionFilterAttributeGroupOperation_NAND
+	};
+
+	
+	class ServiceSubscriptionFilterAttributeGroup
+	{
+		public:
+			std::vector<ServiceSubscriptionFilterAttribute> Attributes;
+			std::vector<ServiceSubscriptionFilterAttributeGroup> Groups;
+			ServiceSubscriptionFilterAttributeGroupOperation Operation;
+			bool SplitStringAttribute;
+        	char SplitStringDelimiter;
+
+			ServiceSubscriptionFilterAttributeGroup();
+			ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation);
+			ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation, std::vector<ServiceSubscriptionFilterAttribute> attributes);
+			ServiceSubscriptionFilterAttributeGroup(ServiceSubscriptionFilterAttributeGroupOperation operation, std::vector<ServiceSubscriptionFilterAttributeGroup> groups);
+
+			bool IsMatch(const std::string& value) const;
+			bool IsMatch(const std::vector<std::string>& values) const;
+			bool IsMatch(const std::map<std::string, std::string>& values) const;
+	};
+}
+
+%template(map_subscriptionattributegroup)  std::map<std::string,RobotRaconteur::ServiceSubscriptionFilterAttributeGroup>;
+
+namespace RobotRaconteur
+{
+
 	class WrappedServiceSubscriptionFilterPredicateDirector
 	{
 	public:
@@ -66,6 +128,8 @@ namespace RobotRaconteur
 		std::vector<std::string> ServiceNames;
 		std::vector<std::string> TransportSchemes;
 		//boost::shared_ptr<WrappedServiceSubscriptionFilterPredicateDirector> Predicate;
+		std::map<std::string,ServiceSubscriptionFilterAttributeGroup> Attributes;
+		ServiceSubscriptionFilterAttributeGroupOperation AttributesMatchOperation;
 		void SetRRPredicateDirector(WrappedServiceSubscriptionFilterPredicateDirector* director, int32_t id);
 		uint32_t MaxConnections;
 	};

--- a/SWIG/Subscription.i
+++ b/SWIG/Subscription.i
@@ -167,7 +167,7 @@ namespace RobotRaconteur
 
 		void UpdateServiceURL(const std::vector<std::string>& url, const std::string& username = "", boost::intrusive_ptr<MessageElementData> credentials=boost::intrusive_ptr<MessageElementData>(),  const std::string& objecttype = "", bool close_connected = false);
 		void UpdateServiceURL(const std::string& url, const std::string& username = "", boost::intrusive_ptr<MessageElementData> credentials=boost::intrusive_ptr<MessageElementData>(),  const std::string& objecttype = "", bool close_connected = false);
-		
+		void UpdateServiceByType(const std::vector<std::string>& service_types, const boost::shared_ptr<WrappedServiceSubscriptionFilter>& filter = boost::shared_ptr<WrappedServiceSubscriptionFilter>());
 			
 	};
 

--- a/test/python/RobotRaconteurTest/test_subscriberfilter.py
+++ b/test/python/RobotRaconteurTest/test_subscriberfilter.py
@@ -10,9 +10,11 @@ object sub_testroot
 end
 """
 
+
 class _sub_testroot_impl(object):
     def __init__(self):
         self.d1 = random.random()
+
 
 def _init_node(nodename, servicename, attributes):
     node1 = RR.RobotRaconteurNode()
@@ -25,9 +27,11 @@ def _init_node(nodename, servicename, attributes):
     node1.RegisterServiceType(_robdef)
 
     c1 = _sub_testroot_impl()
-    c1_context = node1.RegisterService(servicename, "com.robotraconteur.testing.subtestfilter.sub_testroot", c1)
+    c1_context = node1.RegisterService(
+        servicename, "com.robotraconteur.testing.subtestfilter.sub_testroot", c1)
     c1_context.SetServiceAttributes(attributes)
     return node1
+
 
 def _register_service_auth(node, servicename):
     authdata = "testuser1 0b91dec4fe98266a03b136b59219d0d6 objectlock\ntestuser2 841c4221c2e7e0cefbc0392a35222512 objectlock\ntestsuperuser 503ed776c50169f681ad7bbc14198b68 objectlock,objectlockoverride"
@@ -35,7 +39,8 @@ def _register_service_auth(node, servicename):
     policies = {"requirevaliduser": "true", "allowobjectlock": "true"}
     s = RR.ServiceSecurityPolicy(p, policies)
     c1 = _sub_testroot_impl()
-    c1_context = node.RegisterService(servicename, "com.robotraconteur.testing.subtestfilter.sub_testroot", c1, s)
+    c1_context = node.RegisterService(
+        servicename, "com.robotraconteur.testing.subtestfilter.sub_testroot", c1, s)
 
 
 def _init_client_node():
@@ -48,13 +53,14 @@ def _init_client_node():
 
     return node1
 
+
 def _assert_connected_clients(c, count):
     try_count = 0
     if count == 0:
         time.sleep(0.5)
     while True:
         time.sleep(0.1)
-        
+
         try:
             assert len(c.GetConnectedClients()) == count
             break
@@ -64,21 +70,26 @@ def _assert_connected_clients(c, count):
                 raise
             try_count += 1
 
+
 def _run_attributes_filter_test(client_node, attributes_groups, expected_count):
     filter1 = RR.ServiceSubscriptionFilter()
-    
-    for k,v in attributes_groups.items():
+
+    for k, v in attributes_groups.items():
         filter1.Attributes[k] = v
 
-    sub2 = client_node.SubscribeServiceByType(["com.robotraconteur.testing.subtestfilter.sub_testroot"], filter1)
+    sub2 = client_node.SubscribeServiceByType(
+        ["com.robotraconteur.testing.subtestfilter.sub_testroot"], filter1)
     _assert_connected_clients(sub2, expected_count)
     sub2.Close()
 
-def _run_filter_test(client_node, filter_, expected_count):       
-    
-    sub2 = client_node.SubscribeServiceByType(["com.robotraconteur.testing.subtestfilter.sub_testroot"], filter_)
+
+def _run_filter_test(client_node, filter_, expected_count):
+
+    sub2 = client_node.SubscribeServiceByType(
+        ["com.robotraconteur.testing.subtestfilter.sub_testroot"], filter_)
     _assert_connected_clients(sub2, expected_count)
     sub2.Close()
+
 
 def test_subscriber_attribute_filter():
 
@@ -94,36 +105,40 @@ def test_subscriber_attribute_filter():
 
     node2_attrs = {
         "a2": RR.VarValue("test_attr_val2", "string"),
-        "a3": RR.VarValue("test_attr_val3,test_attr_val3_1","string")
+        "a3": RR.VarValue("test_attr_val3,test_attr_val3_1", "string")
     }
-
 
     node1 = _init_node("test_node1", "service1", node1_attrs)
     node2 = _init_node("test_node2", "service2", node2_attrs)
-    
+
     # Create client node
     client_node = _init_client_node()
 
     # Connect and disconnect to make sure everything is working
-    c1 = client_node.ConnectService("rr+intra:///?nodename=test_node1&service=service1")
-    c2 = client_node.ConnectService("rr+intra:///?nodename=test_node2&service=service2")
+    c1 = client_node.ConnectService(
+        "rr+intra:///?nodename=test_node1&service=service1")
+    c2 = client_node.ConnectService(
+        "rr+intra:///?nodename=test_node2&service=service2")
 
     client_node.DisconnectService(c1)
     client_node.DisconnectService(c2)
 
-    sub1 = client_node.SubscribeServiceByType(["com.robotraconteur.testing.subtestfilter.sub_testroot"])
+    sub1 = client_node.SubscribeServiceByType(
+        ["com.robotraconteur.testing.subtestfilter.sub_testroot"])
     _assert_connected_clients(sub1, 2)
     sub1.Close()
 
-    
     attr_grp1 = RR.ServiceSubscriptionFilterAttributeGroup()
-    attr_grp1.Attributes.append(RR.ServiceSubscriptionFilterAttribute("test_attr_val1"))
+    attr_grp1.Attributes.append(
+        RR.ServiceSubscriptionFilterAttribute("test_attr_val1"))
     attr_grps1 = {"a1": attr_grp1}
-    #_run_attributes_filter_test(client_node, attr_grps1, 1)
+    # _run_attributes_filter_test(client_node, attr_grps1, 1)
 
     attr_grp2 = RR.ServiceSubscriptionFilterAttributeGroup()
-    attr_grp2.Attributes.append(RR.ServiceSubscriptionFilterAttribute("test_attr_val1"))
-    attr_grp2.Attributes.append(RR.ServiceSubscriptionFilterAttribute("test_attr_val4"))
+    attr_grp2.Attributes.append(
+        RR.ServiceSubscriptionFilterAttribute("test_attr_val1"))
+    attr_grp2.Attributes.append(
+        RR.ServiceSubscriptionFilterAttribute("test_attr_val4"))
     attr_grps2 = {"a1": attr_grp2}
     _run_attributes_filter_test(client_node, attr_grps2, 1)
 
@@ -131,12 +146,14 @@ def test_subscriber_attribute_filter():
     _run_attributes_filter_test(client_node, attr_grps2, 0)
 
     attr_grp3 = RR.ServiceSubscriptionFilterAttributeGroup()
-    attr_grp3.Attributes.append(RR.CreateServiceSubscriptionFilterAttributeRegex(".*_attr_val1"))
+    attr_grp3.Attributes.append(
+        RR.CreateServiceSubscriptionFilterAttributeRegex(".*_attr_val1"))
     attr_grps3 = {"a1": attr_grp3}
     _run_attributes_filter_test(client_node, attr_grps3, 1)
 
     node1.Shutdown()
     node2.Shutdown()
+
 
 def test_subscriber_filter():
 
@@ -146,23 +163,28 @@ def test_subscriber_filter():
     node4 = _init_node("test_node4", "service2", {})
 
     _register_service_auth(node3, "service1")
-    
+
     # Create client node
     client_node = _init_client_node()
 
     # Connect and disconnect to make sure everything is working
-    c1 = client_node.ConnectService("rr+intra:///?nodename=test_node1&service=service1")
-    c2 = client_node.ConnectService("rr+intra:///?nodename=test_node2&service=service1")
+    c1 = client_node.ConnectService(
+        "rr+intra:///?nodename=test_node1&service=service1")
+    c2 = client_node.ConnectService(
+        "rr+intra:///?nodename=test_node2&service=service1")
     cred1 = {"password": RR.VarValue("testpass1", "string")}
-    c3 = client_node.ConnectService("rr+intra:///?nodename=test_node3&service=service1", "testuser1", cred1)
-    c4 = client_node.ConnectService("rr+intra:///?nodename=test_node4&service=service2")
+    c3 = client_node.ConnectService(
+        "rr+intra:///?nodename=test_node3&service=service1", "testuser1", cred1)
+    c4 = client_node.ConnectService(
+        "rr+intra:///?nodename=test_node4&service=service2")
 
     client_node.DisconnectService(c1)
     client_node.DisconnectService(c2)
     client_node.DisconnectService(c3)
     client_node.DisconnectService(c4)
 
-    sub1 = client_node.SubscribeServiceByType(["com.robotraconteur.testing.subtestfilter.sub_testroot"])
+    sub1 = client_node.SubscribeServiceByType(
+        ["com.robotraconteur.testing.subtestfilter.sub_testroot"])
     _assert_connected_clients(sub1, 5)
     sub1.Close()
 
@@ -178,7 +200,7 @@ def test_subscriber_filter():
     filter2 = RR.ServiceSubscriptionFilter()
     filter2_node = RR.ServiceSubscriptionFilterNode()
     filter2_node.NodeName = "test_node3"
-    filter2_node.Username = "testuser1"    
+    filter2_node.Username = "testuser1"
     filter2_node.Credentials = {"password": RR.VarValue("testpass1", "string")}
     filter2.ServiceNames.append("service1")
     filter2.Nodes.append(filter2_node)

--- a/test/python/RobotRaconteurTest/test_subscriberfilter.py
+++ b/test/python/RobotRaconteurTest/test_subscriberfilter.py
@@ -1,0 +1,190 @@
+import RobotRaconteur as RR
+import random
+import time
+
+_robdef = """
+service com.robotraconteur.testing.subtestfilter
+
+object sub_testroot
+    property double d1
+end
+"""
+
+class _sub_testroot_impl(object):
+    def __init__(self):
+        self.d1 = random.random()
+
+def _init_node(nodename, servicename, attributes):
+    node1 = RR.RobotRaconteurNode()
+    node1.Init()
+    node1.SetNodeName(nodename)
+    t1 = RR.IntraTransport(node1)
+    node1.RegisterTransport(t1)
+    t1.StartServer()
+
+    node1.RegisterServiceType(_robdef)
+
+    c1 = _sub_testroot_impl()
+    c1_context = node1.RegisterService(servicename, "com.robotraconteur.testing.subtestfilter.sub_testroot", c1)
+    c1_context.SetServiceAttributes(attributes)
+    return node1
+
+def _register_service_auth(node, servicename):
+    authdata = "testuser1 0b91dec4fe98266a03b136b59219d0d6 objectlock\ntestuser2 841c4221c2e7e0cefbc0392a35222512 objectlock\ntestsuperuser 503ed776c50169f681ad7bbc14198b68 objectlock,objectlockoverride"
+    p = RR.PasswordFileUserAuthenticator(authdata)
+    policies = {"requirevaliduser": "true", "allowobjectlock": "true"}
+    s = RR.ServiceSecurityPolicy(p, policies)
+    c1 = _sub_testroot_impl()
+    c1_context = node.RegisterService(servicename, "com.robotraconteur.testing.subtestfilter.sub_testroot", c1, s)
+
+
+def _init_client_node():
+    node1 = RR.RobotRaconteurNode()
+    node1.Init()
+    t1 = RR.IntraTransport(node1)
+    node1.RegisterTransport(t1)
+    t1.StartClient()
+    node1.SetLogLevelFromString("WARNING")
+
+    return node1
+
+def _assert_connected_clients(c, count):
+    try_count = 0
+    if count == 0:
+        time.sleep(0.5)
+    while True:
+        time.sleep(0.1)
+        
+        try:
+            assert len(c.GetConnectedClients()) == count
+            break
+        except AssertionError:
+            if try_count > 50:
+                print(len(c.GetConnectedClients()))
+                raise
+            try_count += 1
+
+def _run_attributes_filter_test(client_node, attributes_groups, expected_count):
+    filter1 = RR.ServiceSubscriptionFilter()
+    
+    for k,v in attributes_groups.items():
+        filter1.Attributes[k] = v
+
+    sub2 = client_node.SubscribeServiceByType(["com.robotraconteur.testing.subtestfilter.sub_testroot"], filter1)
+    _assert_connected_clients(sub2, expected_count)
+    sub2.Close()
+
+def _run_filter_test(client_node, filter_, expected_count):       
+    
+    sub2 = client_node.SubscribeServiceByType(["com.robotraconteur.testing.subtestfilter.sub_testroot"], filter_)
+    _assert_connected_clients(sub2, expected_count)
+    sub2.Close()
+
+def test_subscriber_attribute_filter():
+
+    # Use IntraTransport for tests so everything is local to the test
+
+    # Create server nodes
+
+    node1_attrs = {
+        "a1": RR.VarValue("test_attr_val1", "string"),
+        "a2": RR.VarValue("test_attr_val2", "string"),
+        "a4": RR.VarValue("test_attr_val4,test_attr_val4_1", "string")
+    }
+
+    node2_attrs = {
+        "a2": RR.VarValue("test_attr_val2", "string"),
+        "a3": RR.VarValue("test_attr_val3,test_attr_val3_1","string")
+    }
+
+
+    node1 = _init_node("test_node1", "service1", node1_attrs)
+    node2 = _init_node("test_node2", "service2", node2_attrs)
+    
+    # Create client node
+    client_node = _init_client_node()
+
+    # Connect and disconnect to make sure everything is working
+    c1 = client_node.ConnectService("rr+intra:///?nodename=test_node1&service=service1")
+    c2 = client_node.ConnectService("rr+intra:///?nodename=test_node2&service=service2")
+
+    client_node.DisconnectService(c1)
+    client_node.DisconnectService(c2)
+
+    sub1 = client_node.SubscribeServiceByType(["com.robotraconteur.testing.subtestfilter.sub_testroot"])
+    _assert_connected_clients(sub1, 2)
+    sub1.Close()
+
+    
+    attr_grp1 = RR.ServiceSubscriptionFilterAttributeGroup()
+    attr_grp1.Attributes.append(RR.ServiceSubscriptionFilterAttribute("test_attr_val1"))
+    attr_grps1 = {"a1": attr_grp1}
+    #_run_attributes_filter_test(client_node, attr_grps1, 1)
+
+    attr_grp2 = RR.ServiceSubscriptionFilterAttributeGroup()
+    attr_grp2.Attributes.append(RR.ServiceSubscriptionFilterAttribute("test_attr_val1"))
+    attr_grp2.Attributes.append(RR.ServiceSubscriptionFilterAttribute("test_attr_val4"))
+    attr_grps2 = {"a1": attr_grp2}
+    _run_attributes_filter_test(client_node, attr_grps2, 1)
+
+    attr_grp2.Operation = RR.ServiceSubscriptionFilterAttributeGroupOperation_AND
+    _run_attributes_filter_test(client_node, attr_grps2, 0)
+
+    attr_grp3 = RR.ServiceSubscriptionFilterAttributeGroup()
+    attr_grp3.Attributes.append(RR.CreateServiceSubscriptionFilterAttributeRegex(".*_attr_val1"))
+    attr_grps3 = {"a1": attr_grp3}
+    _run_attributes_filter_test(client_node, attr_grps3, 1)
+
+    node1.Shutdown()
+    node2.Shutdown()
+
+def test_subscriber_filter():
+
+    node1 = _init_node("test_node1", "service1", {})
+    node2 = _init_node("test_node2", "service1", {})
+    node3 = _init_node("test_node3", "service3", {})
+    node4 = _init_node("test_node4", "service2", {})
+
+    _register_service_auth(node3, "service1")
+    
+    # Create client node
+    client_node = _init_client_node()
+
+    # Connect and disconnect to make sure everything is working
+    c1 = client_node.ConnectService("rr+intra:///?nodename=test_node1&service=service1")
+    c2 = client_node.ConnectService("rr+intra:///?nodename=test_node2&service=service1")
+    cred1 = {"password": RR.VarValue("testpass1", "string")}
+    c3 = client_node.ConnectService("rr+intra:///?nodename=test_node3&service=service1", "testuser1", cred1)
+    c4 = client_node.ConnectService("rr+intra:///?nodename=test_node4&service=service2")
+
+    client_node.DisconnectService(c1)
+    client_node.DisconnectService(c2)
+    client_node.DisconnectService(c3)
+    client_node.DisconnectService(c4)
+
+    sub1 = client_node.SubscribeServiceByType(["com.robotraconteur.testing.subtestfilter.sub_testroot"])
+    _assert_connected_clients(sub1, 5)
+    sub1.Close()
+
+    filter1 = RR.ServiceSubscriptionFilter()
+    filter1.ServiceNames.append("service1")
+    _run_filter_test(client_node, filter1, 3)
+
+    filter1_node = RR.ServiceSubscriptionFilterNode()
+    filter1_node.NodeName = "test_node1"
+    filter1.Nodes.append(filter1_node)
+    _run_filter_test(client_node, filter1, 1)
+
+    filter2 = RR.ServiceSubscriptionFilter()
+    filter2_node = RR.ServiceSubscriptionFilterNode()
+    filter2_node.NodeName = "test_node3"
+    filter2_node.Username = "testuser1"    
+    filter2_node.Credentials = {"password": RR.VarValue("testpass1", "string")}
+    filter2.ServiceNames.append("service1")
+    filter2.Nodes.append(filter2_node)
+    _run_filter_test(client_node, filter2, 1)
+
+    node1.Shutdown()
+    node2.Shutdown()
+    node3.Shutdown()
+    node4.Shutdown()


### PR DESCRIPTION
This PR does the following:

* Add the `UpdateServiceByType()` to `ServiceSubscription` to allow for the desired search types and the filter to be updated without creating a new subscription.
* Add `Attributes` filter to the `ServiceSubscriptionFilter`. This will allow for more flexibility in designing node filters without requiring a custom callback function.
* Fix the node discovery in `IntraTransport` that was not working properly. Add the `StartClient()` function to enable discovery correctly.
* Fix bug with `ServiceSubscriptionClientID` taking a reference to `NodeID` instead of copying in wrappers, leading to a segfault.
* Add subscription tests using `IntraTransport`