### PR TITLE
Fix boost::asio::ssl::stream concurrency problems

### DIFF
--- a/RobotRaconteurCore/include/RobotRaconteur/RobotRaconteurConfig.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/RobotRaconteurConfig.h
@@ -128,7 +128,6 @@
 #define RR_BOOST_ASIO_STRAND_WRAP(strand, f) (strand).wrap(f)
 #define RR_BOOST_ASIO_NEW_STRAND(context) (new boost::asio::strand(context))
 #define RR_BOOST_ASIO_GET_IO_SERVICE(s) (s).get_io_service()
-#define RR_BOOST_ASIO_MAKE_STRAND(x) boost::asio::strand(x)
 #define RR_BOOST_ASIO_REF_IO_SERVICE(x) boost::ref(x)
 #define RR_BOOST_ASIO_NEW_API_CONST
 #else
@@ -140,10 +139,15 @@
 #define RR_BOOST_ASIO_STRAND_WRAP(strand, f) boost::asio::bind_executor(strand, f)
 #define RR_BOOST_ASIO_NEW_STRAND(context)                                                                              \
     (new boost::asio::strand<boost::asio::io_context::executor_type>((context).get_executor()))
-#define RR_BOOST_ASIO_MAKE_STRAND(x) boost::asio::make_strand(x)
 #define RR_BOOST_ASIO_GET_IO_SERVICE(s) (s).get_executor()
 #define RR_BOOST_ASIO_REF_IO_SERVICE(x) (x)
 #define RR_BOOST_ASIO_NEW_API_CONST const
+#endif
+
+#if BOOST_ASIO_VERSION < 101400
+#define RR_BOOST_ASIO_MAKE_STRAND(x) boost::asio::strand(x)
+#else
+#define RR_BOOST_ASIO_MAKE_STRAND(x) boost::asio::make_strand(x)
 #endif
 
 #if BOOST_VERSION <= 105900

--- a/RobotRaconteurCore/include/RobotRaconteur/RobotRaconteurConfig.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/RobotRaconteurConfig.h
@@ -130,6 +130,7 @@
 #define RR_BOOST_ASIO_GET_IO_SERVICE(s) (s).get_io_service()
 #define RR_BOOST_ASIO_MAKE_STRAND(x) boost::asio::strand(x)
 #define RR_BOOST_ASIO_REF_IO_SERVICE(x) boost::ref(x)
+#define RR_BOOST_ASIO_NEW_API_CONST
 #else
 #define RR_BOOST_ASIO_IO_CONTEXT boost::asio::io_context
 #define RR_BOOST_ASIO_STRAND boost::asio::strand<boost::asio::io_context::executor_type>
@@ -142,6 +143,7 @@
 #define RR_BOOST_ASIO_MAKE_STRAND(x) boost::asio::make_strand(x)
 #define RR_BOOST_ASIO_GET_IO_SERVICE(s) (s).get_executor()
 #define RR_BOOST_ASIO_REF_IO_SERVICE(x) (x)
+#define RR_BOOST_ASIO_NEW_API_CONST const
 #endif
 
 #if BOOST_VERSION <= 105900

--- a/RobotRaconteurCore/include/RobotRaconteur/RobotRaconteurConfig.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/RobotRaconteurConfig.h
@@ -110,9 +110,11 @@
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 #define RR_MOVE_ARG(type) type&&
 #define RR_MOVE(x) std::move(x)
+#define RR_FORWARD(type, x) std::forward<type>(x)
 #else
 #define RR_MOVE_ARG(type) type
 #define RR_MOVE(x) x
+#define RR_FORWARD(type, x) x
 #endif
 
 #include <boost/asio/version.hpp>
@@ -120,18 +122,26 @@
 #if BOOST_ASIO_VERSION < 101200
 #define RR_BOOST_ASIO_IO_CONTEXT boost::asio::io_service
 #define RR_BOOST_ASIO_STRAND boost::asio::io_service::strand
+#define RR_BOOST_ASIO_STRAND2(exec_type) boost::asio::io_service::strand
 #define RR_BOOST_ASIO_POST(context, func) context.post(func)
 #define RR_BOOST_ASIO_BUFFER_CAST(type, buf) boost::asio::buffer_cast<type>(buf)
 #define RR_BOOST_ASIO_STRAND_WRAP(strand, f) (strand).wrap(f)
 #define RR_BOOST_ASIO_NEW_STRAND(context) (new boost::asio::strand(context))
+#define RR_BOOST_ASIO_GET_IO_SERVICE(s) (s).get_io_service()
+#define RR_BOOST_ASIO_MAKE_STRAND(x) boost::asio::strand(x)
+#define RR_BOOST_ASIO_REF_IO_SERVICE(x) boost::ref(x)
 #else
 #define RR_BOOST_ASIO_IO_CONTEXT boost::asio::io_context
 #define RR_BOOST_ASIO_STRAND boost::asio::strand<boost::asio::io_context::executor_type>
+#define RR_BOOST_ASIO_STRAND2(exec_type) boost::asio::strand<exec_type>
 #define RR_BOOST_ASIO_POST(context, func) boost::asio::post(context, func)
 #define RR_BOOST_ASIO_BUFFER_CAST(type, buf) (type)(buf).data()
 #define RR_BOOST_ASIO_STRAND_WRAP(strand, f) boost::asio::bind_executor(strand, f)
 #define RR_BOOST_ASIO_NEW_STRAND(context)                                                                              \
     (new boost::asio::strand<boost::asio::io_context::executor_type>((context).get_executor()))
+#define RR_BOOST_ASIO_MAKE_STRAND(x) boost::asio::make_strand(x)
+#define RR_BOOST_ASIO_GET_IO_SERVICE(s) (s).get_executor()
+#define RR_BOOST_ASIO_REF_IO_SERVICE(x) (x)
 #endif
 
 #if BOOST_VERSION <= 105900

--- a/RobotRaconteurCore/include/RobotRaconteur/RobotRaconteurConfig.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/RobotRaconteurConfig.h
@@ -144,8 +144,10 @@
 #define RR_BOOST_ASIO_NEW_API_CONST const
 #endif
 
-#if BOOST_ASIO_VERSION < 101400
+#if BOOST_ASIO_VERSION < 101200
 #define RR_BOOST_ASIO_MAKE_STRAND(exec_type,x) boost::asio::strand(x)
+#elif BOOST_ASIO_VERSION < 101400
+#define RR_BOOST_ASIO_MAKE_STRAND(exec_type,x) boost::asio::strand<exec_type>(x)
 #else
 #define RR_BOOST_ASIO_MAKE_STRAND(exec_type,x) boost::asio::make_strand<exec_type>(x)
 #endif

--- a/RobotRaconteurCore/include/RobotRaconteur/RobotRaconteurConfig.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/RobotRaconteurConfig.h
@@ -145,11 +145,11 @@
 #endif
 
 #if BOOST_ASIO_VERSION < 101200
-#define RR_BOOST_ASIO_MAKE_STRAND(exec_type,x) boost::asio::strand(x)
+#define RR_BOOST_ASIO_MAKE_STRAND(exec_type, x) boost::asio::strand(x)
 #elif BOOST_ASIO_VERSION < 101400
-#define RR_BOOST_ASIO_MAKE_STRAND(exec_type,x) boost::asio::strand<exec_type>(x)
+#define RR_BOOST_ASIO_MAKE_STRAND(exec_type, x) boost::asio::strand<exec_type>(x)
 #else
-#define RR_BOOST_ASIO_MAKE_STRAND(exec_type,x) boost::asio::make_strand<exec_type>(x)
+#define RR_BOOST_ASIO_MAKE_STRAND(exec_type, x) boost::asio::make_strand<exec_type>(x)
 #endif
 
 #if BOOST_VERSION <= 105900

--- a/RobotRaconteurCore/include/RobotRaconteur/RobotRaconteurConfig.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/RobotRaconteurConfig.h
@@ -145,9 +145,9 @@
 #endif
 
 #if BOOST_ASIO_VERSION < 101400
-#define RR_BOOST_ASIO_MAKE_STRAND(x) boost::asio::strand(x)
+#define RR_BOOST_ASIO_MAKE_STRAND(exec_type,x) boost::asio::strand(x)
 #else
-#define RR_BOOST_ASIO_MAKE_STRAND(x) boost::asio::make_strand(x)
+#define RR_BOOST_ASIO_MAKE_STRAND(exec_type,x) boost::asio::make_strand<exec_type>(x)
 #endif
 
 #if BOOST_VERSION <= 105900

--- a/RobotRaconteurCore/src/TcpTransport.cpp
+++ b/RobotRaconteurCore/src/TcpTransport.cpp
@@ -1479,7 +1479,8 @@ void TcpWSSWebSocketConnector::Connect4(
     const RR_SHARED_PTR<RobotRaconteurException>& err, const RR_SHARED_PTR<ITransportConnection>& connection,
     const RR_SHARED_PTR<boost::asio::ip::tcp::socket>& socket,
     const RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >& tls_stream,
-    const RR_SHARED_PTR<websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >& websocket,
+    const RR_SHARED_PTR<websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >&
+        websocket,
     const boost::function<void(const RR_SHARED_PTR<ITransportConnection>&,
                                const RR_SHARED_PTR<RobotRaconteurException>&)>& handler)
 {
@@ -1516,7 +1517,8 @@ void TcpWSSWebSocketConnector::Connect3(
     const boost::system::error_code& ec, const RR_SHARED_PTR<boost::asio::ip::tcp::socket>& socket,
     const RR_SHARED_PTR<boost::signals2::scoped_connection>& socket_closer,
     const RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >& tls_stream,
-    const RR_SHARED_PTR<websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >& websocket,
+    const RR_SHARED_PTR<websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >&
+        websocket,
     const boost::function<void(const RR_SHARED_PTR<ITransportConnection>&,
                                const RR_SHARED_PTR<RobotRaconteurException>&)>& handler)
 {
@@ -1718,12 +1720,12 @@ void TcpWSSWebSocketConnector::Connect2(
 
         RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> > tls_stream =
             RR_MAKE_SHARED<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >(boost::ref(*socket),
-                                                                                     boost::ref(*context));
+                                                                                               boost::ref(*context));
 
-        RobotRaconteurNode::asio_async_handshake(
-            node, tls_stream, boost::asio::ssl::stream_base::client,
-            boost::bind(&TcpWSSWebSocketConnector::Connect2_1, shared_from_this(), RR_BOOST_PLACEHOLDERS(_1), socket,
-                        socket_closer, tls_stream, boost::protect(handler)));
+        RobotRaconteurNode::asio_async_handshake(node, tls_stream, boost::asio::ssl::stream_base::client,
+                                                 boost::bind(&TcpWSSWebSocketConnector::Connect2_1, shared_from_this(),
+                                                             RR_BOOST_PLACEHOLDERS(_1), socket, socket_closer,
+                                                             tls_stream, boost::protect(handler)));
     }
     catch (std::exception& exp)
     {
@@ -4261,12 +4263,11 @@ void TcpTransportConnection::do_starttls4(const std::string& servername, const b
         else if (use_websocket)
         {
             tls_context = RR_STATIC_POINTER_CAST<detail::OpenSSLAuthContext>(p->GetTlsContext());
-            tls_websocket =
-                RR_MAKE_SHARED<detail::asio_ssl_stream_threadsafe<detail::websocket_stream<boost::asio::ip::tcp::socket&>&> >(
-                    boost::ref(*websocket), boost::ref(*(tls_context->GetClientCredentials())));
+            tls_websocket = RR_MAKE_SHARED<
+                detail::asio_ssl_stream_threadsafe<detail::websocket_stream<boost::asio::ip::tcp::socket&>&> >(
+                boost::ref(*websocket), boost::ref(*(tls_context->GetClientCredentials())));
             RobotRaconteurNode::asio_async_handshake(
-                node, tls_websocket,
-                boost::asio::ssl::stream_base::client,
+                node, tls_websocket, boost::asio::ssl::stream_base::client,
                 boost::bind(&TcpTransportConnection::do_starttls5,
                             RR_STATIC_POINTER_CAST<TcpTransportConnection>(shared_from_this()),
                             RR_BOOST_PLACEHOLDERS(_1)));
@@ -4279,8 +4280,7 @@ void TcpTransportConnection::do_starttls4(const std::string& servername, const b
                 detail::websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&>&> >(
                 boost::ref(*wss_websocket), boost::ref(*(tls_context->GetClientCredentials())));
             RobotRaconteurNode::asio_async_handshake(
-                node, tls_wss_websocket,
-                boost::asio::ssl::stream_base::client,
+                node, tls_wss_websocket, boost::asio::ssl::stream_base::client,
                 boost::bind(&TcpTransportConnection::do_starttls5,
                             RR_STATIC_POINTER_CAST<TcpTransportConnection>(shared_from_this()),
                             RR_BOOST_PLACEHOLDERS(_1)));
@@ -4678,9 +4678,9 @@ void TcpTransportConnection::do_starttls8(const RR_SHARED_PTR<RobotRaconteurExce
         else if (use_websocket)
         {
             tls_context = RR_STATIC_POINTER_CAST<detail::OpenSSLAuthContext>(p->GetTlsContext());
-            tls_websocket =
-                RR_MAKE_SHARED<detail::asio_ssl_stream_threadsafe<detail::websocket_stream<boost::asio::ip::tcp::socket&>&> >(
-                    boost::ref(*websocket), boost::ref(*(tls_context->GetServerCredentials())));
+            tls_websocket = RR_MAKE_SHARED<
+                detail::asio_ssl_stream_threadsafe<detail::websocket_stream<boost::asio::ip::tcp::socket&>&> >(
+                boost::ref(*websocket), boost::ref(*(tls_context->GetServerCredentials())));
 
             if (tls_mutual_auth)
             {
@@ -4706,8 +4706,7 @@ void TcpTransportConnection::do_starttls8(const RR_SHARED_PTR<RobotRaconteurExce
                                  ::SSL_CTX_get_verify_callback(tls_context->GetServerCredentials()->native_handle()));
             }
             RobotRaconteurNode::asio_async_handshake(
-                node, tls_wss_websocket,
-                boost::asio::ssl::stream_base::server,
+                node, tls_wss_websocket, boost::asio::ssl::stream_base::server,
                 boost::bind(&TcpTransportConnection::do_starttls9,
                             RR_STATIC_POINTER_CAST<TcpTransportConnection>(shared_from_this()),
                             RR_BOOST_PLACEHOLDERS(_1)));

--- a/RobotRaconteurCore/src/TcpTransport.cpp
+++ b/RobotRaconteurCore/src/TcpTransport.cpp
@@ -1478,8 +1478,8 @@ void TcpWSSWebSocketConnector::Connect(
 void TcpWSSWebSocketConnector::Connect4(
     const RR_SHARED_PTR<RobotRaconteurException>& err, const RR_SHARED_PTR<ITransportConnection>& connection,
     const RR_SHARED_PTR<boost::asio::ip::tcp::socket>& socket,
-    const RR_SHARED_PTR<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> >& tls_stream,
-    const RR_SHARED_PTR<websocket_stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>&> >& websocket,
+    const RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >& tls_stream,
+    const RR_SHARED_PTR<websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >& websocket,
     const boost::function<void(const RR_SHARED_PTR<ITransportConnection>&,
                                const RR_SHARED_PTR<RobotRaconteurException>&)>& handler)
 {
@@ -1515,8 +1515,8 @@ void TcpWSSWebSocketConnector::Connect4(
 void TcpWSSWebSocketConnector::Connect3(
     const boost::system::error_code& ec, const RR_SHARED_PTR<boost::asio::ip::tcp::socket>& socket,
     const RR_SHARED_PTR<boost::signals2::scoped_connection>& socket_closer,
-    const RR_SHARED_PTR<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> >& tls_stream,
-    const RR_SHARED_PTR<websocket_stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>&> >& websocket,
+    const RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >& tls_stream,
+    const RR_SHARED_PTR<websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >& websocket,
     const boost::function<void(const RR_SHARED_PTR<ITransportConnection>&,
                                const RR_SHARED_PTR<RobotRaconteurException>&)>& handler)
 {
@@ -1555,7 +1555,7 @@ void TcpWSSWebSocketConnector::Connect3(
 void TcpWSSWebSocketConnector::Connect2_1(
     const boost::system::error_code& ec, const RR_SHARED_PTR<boost::asio::ip::tcp::socket>& socket,
     const RR_SHARED_PTR<boost::signals2::scoped_connection>& socket_closer,
-    const RR_SHARED_PTR<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> >& tls_stream,
+    const RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >& tls_stream,
     const boost::function<void(const RR_SHARED_PTR<ITransportConnection>&,
                                const RR_SHARED_PTR<RobotRaconteurException>&)>& handler)
 {
@@ -1571,8 +1571,8 @@ void TcpWSSWebSocketConnector::Connect2_1(
     try
     {
         ROBOTRACONTEUR_LOG_TRACE_COMPONENT(node, Transport, endpoint, "wss tcp socket connected, begin handshake");
-        RR_SHARED_PTR<websocket_stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>&> > websocket =
-            RR_MAKE_SHARED<websocket_stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>&> >(
+        RR_SHARED_PTR<websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> > websocket =
+            RR_MAKE_SHARED<websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >(
                 boost::ref(*tls_stream));
         websocket->async_client_handshake(ws_url, "robotraconteur.robotraconteur.com",
                                           boost::bind(&TcpWSSWebSocketConnector::Connect3, shared_from_this(),
@@ -1716,12 +1716,12 @@ void TcpWSSWebSocketConnector::Connect2(
                                                  RR_BOOST_PLACEHOLDERS(_2), servername));
 #endif
 
-        RR_SHARED_PTR<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> > tls_stream =
-            RR_MAKE_SHARED<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> >(boost::ref(*socket),
+        RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> > tls_stream =
+            RR_MAKE_SHARED<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >(boost::ref(*socket),
                                                                                      boost::ref(*context));
 
         RobotRaconteurNode::asio_async_handshake(
-            node, tls_stream, boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>::client,
+            node, tls_stream, boost::asio::ssl::stream_base::client,
             boost::bind(&TcpWSSWebSocketConnector::Connect2_1, shared_from_this(), RR_BOOST_PLACEHOLDERS(_1), socket,
                         socket_closer, tls_stream, boost::protect(handler)));
     }
@@ -3870,8 +3870,8 @@ void TcpTransportConnection::AsyncAttachWSSWebSocket(
 #ifdef ROBOTRACONTEUR_USE_OPENSSL
 void TcpTransportConnection::AsyncAttachWSSWebSocket(
     const RR_SHARED_PTR<boost::asio::ip::tcp::socket>& socket,
-    const RR_SHARED_PTR<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> >& wss_websocket_tls,
-    const RR_SHARED_PTR<detail::websocket_stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>&> >&
+    const RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >& wss_websocket_tls,
+    const RR_SHARED_PTR<detail::websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >&
         wss_websocket,
     const RR_SHARED_PTR<boost::asio::ssl::context>& wss_context,
     const boost::function<void(const RR_SHARED_PTR<RobotRaconteurException>&)>& callback)
@@ -4250,10 +4250,10 @@ void TcpTransportConnection::do_starttls4(const std::string& servername, const b
         if (!use_websocket && !use_wss_websocket)
         {
             tls_context = RR_STATIC_POINTER_CAST<detail::OpenSSLAuthContext>(p->GetTlsContext());
-            tls_socket = RR_MAKE_SHARED<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> >(
+            tls_socket = RR_MAKE_SHARED<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >(
                 boost::ref(*socket), boost::ref(*(tls_context->GetClientCredentials())));
             RobotRaconteurNode::asio_async_handshake(
-                node, tls_socket, boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>::client,
+                node, tls_socket, boost::asio::ssl::stream_base::client,
                 boost::bind(&TcpTransportConnection::do_starttls5,
                             RR_STATIC_POINTER_CAST<TcpTransportConnection>(shared_from_this()),
                             RR_BOOST_PLACEHOLDERS(_1)));
@@ -4262,11 +4262,11 @@ void TcpTransportConnection::do_starttls4(const std::string& servername, const b
         {
             tls_context = RR_STATIC_POINTER_CAST<detail::OpenSSLAuthContext>(p->GetTlsContext());
             tls_websocket =
-                RR_MAKE_SHARED<boost::asio::ssl::stream<detail::websocket_stream<boost::asio::ip::tcp::socket&>&> >(
+                RR_MAKE_SHARED<detail::asio_ssl_stream_threadsafe<detail::websocket_stream<boost::asio::ip::tcp::socket&>&> >(
                     boost::ref(*websocket), boost::ref(*(tls_context->GetClientCredentials())));
             RobotRaconteurNode::asio_async_handshake(
                 node, tls_websocket,
-                boost::asio::ssl::stream<detail::websocket_stream<boost::asio::ip::tcp::socket&>&>::client,
+                boost::asio::ssl::stream_base::client,
                 boost::bind(&TcpTransportConnection::do_starttls5,
                             RR_STATIC_POINTER_CAST<TcpTransportConnection>(shared_from_this()),
                             RR_BOOST_PLACEHOLDERS(_1)));
@@ -4275,13 +4275,12 @@ void TcpTransportConnection::do_starttls4(const std::string& servername, const b
         {
 
             tls_context = RR_STATIC_POINTER_CAST<detail::OpenSSLAuthContext>(p->GetTlsContext());
-            tls_wss_websocket = RR_MAKE_SHARED<boost::asio::ssl::stream<
-                detail::websocket_stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>&>&> >(
+            tls_wss_websocket = RR_MAKE_SHARED<detail::asio_ssl_stream_threadsafe<
+                detail::websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&>&> >(
                 boost::ref(*wss_websocket), boost::ref(*(tls_context->GetClientCredentials())));
             RobotRaconteurNode::asio_async_handshake(
                 node, tls_wss_websocket,
-                boost::asio::ssl::stream<
-                    detail::websocket_stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>&>&>::client,
+                boost::asio::ssl::stream_base::client,
                 boost::bind(&TcpTransportConnection::do_starttls5,
                             RR_STATIC_POINTER_CAST<TcpTransportConnection>(shared_from_this()),
                             RR_BOOST_PLACEHOLDERS(_1)));
@@ -4662,7 +4661,7 @@ void TcpTransportConnection::do_starttls8(const RR_SHARED_PTR<RobotRaconteurExce
         if (!use_websocket && !use_wss_websocket)
         {
             tls_context = RR_STATIC_POINTER_CAST<detail::OpenSSLAuthContext>(p->GetTlsContext());
-            tls_socket = RR_MAKE_SHARED<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> >(
+            tls_socket = RR_MAKE_SHARED<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >(
                 boost::ref(*socket), boost::ref(*(tls_context->GetServerCredentials())));
 
             if (tls_mutual_auth)
@@ -4671,7 +4670,7 @@ void TcpTransportConnection::do_starttls8(const RR_SHARED_PTR<RobotRaconteurExce
                                  ::SSL_CTX_get_verify_callback(tls_context->GetServerCredentials()->native_handle()));
             }
             RobotRaconteurNode::asio_async_handshake(
-                node, tls_socket, boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>::server,
+                node, tls_socket, boost::asio::ssl::stream_base::server,
                 boost::bind(&TcpTransportConnection::do_starttls9,
                             RR_STATIC_POINTER_CAST<TcpTransportConnection>(shared_from_this()),
                             RR_BOOST_PLACEHOLDERS(_1)));
@@ -4680,7 +4679,7 @@ void TcpTransportConnection::do_starttls8(const RR_SHARED_PTR<RobotRaconteurExce
         {
             tls_context = RR_STATIC_POINTER_CAST<detail::OpenSSLAuthContext>(p->GetTlsContext());
             tls_websocket =
-                RR_MAKE_SHARED<boost::asio::ssl::stream<detail::websocket_stream<boost::asio::ip::tcp::socket&>&> >(
+                RR_MAKE_SHARED<detail::asio_ssl_stream_threadsafe<detail::websocket_stream<boost::asio::ip::tcp::socket&>&> >(
                     boost::ref(*websocket), boost::ref(*(tls_context->GetServerCredentials())));
 
             if (tls_mutual_auth)
@@ -4689,7 +4688,7 @@ void TcpTransportConnection::do_starttls8(const RR_SHARED_PTR<RobotRaconteurExce
                                  ::SSL_CTX_get_verify_callback(tls_context->GetServerCredentials()->native_handle()));
             }
             RobotRaconteurNode::asio_async_handshake(
-                node, tls_websocket, boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>::server,
+                node, tls_websocket, boost::asio::ssl::stream_base::server,
                 boost::bind(&TcpTransportConnection::do_starttls9,
                             RR_STATIC_POINTER_CAST<TcpTransportConnection>(shared_from_this()),
                             RR_BOOST_PLACEHOLDERS(_1)));
@@ -4697,8 +4696,8 @@ void TcpTransportConnection::do_starttls8(const RR_SHARED_PTR<RobotRaconteurExce
         else
         {
             tls_context = RR_STATIC_POINTER_CAST<detail::OpenSSLAuthContext>(p->GetTlsContext());
-            tls_wss_websocket = RR_MAKE_SHARED<boost::asio::ssl::stream<
-                detail::websocket_stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>&>&> >(
+            tls_wss_websocket = RR_MAKE_SHARED<detail::asio_ssl_stream_threadsafe<
+                detail::websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&>&> >(
                 boost::ref(*wss_websocket), boost::ref(*(tls_context->GetServerCredentials())));
 
             if (tls_mutual_auth)
@@ -4708,8 +4707,7 @@ void TcpTransportConnection::do_starttls8(const RR_SHARED_PTR<RobotRaconteurExce
             }
             RobotRaconteurNode::asio_async_handshake(
                 node, tls_wss_websocket,
-                boost::asio::ssl::stream<
-                    detail::websocket_stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>&>&>::server,
+                boost::asio::ssl::stream_base::server,
                 boost::bind(&TcpTransportConnection::do_starttls9,
                             RR_STATIC_POINTER_CAST<TcpTransportConnection>(shared_from_this()),
                             RR_BOOST_PLACEHOLDERS(_1)));

--- a/RobotRaconteurCore/src/TcpTransport_private.h
+++ b/RobotRaconteurCore/src/TcpTransport_private.h
@@ -24,6 +24,7 @@
 
 #ifdef ROBOTRACONTEUR_USE_OPENSSL
 #include <boost/asio/ssl.hpp>
+#include "asio_ssl_stream_threadsafe.h"
 #include "OpenSSLAuthContext.h"
 #endif
 
@@ -63,8 +64,8 @@ class TcpTransportConnection : public detail::ASIOStreamBaseTransport
 #ifdef ROBOTRACONTEUR_USE_OPENSSL
     void AsyncAttachWSSWebSocket(
         const RR_SHARED_PTR<boost::asio::ip::tcp::socket>& socket,
-        const RR_SHARED_PTR<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> >& wss_websocket_tls,
-        const RR_SHARED_PTR<detail::websocket_stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>&> >&
+        const RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >& wss_websocket_tls,
+        const RR_SHARED_PTR<detail::websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >&
             wss_websocket,
         const RR_SHARED_PTR<boost::asio::ssl::context>& wss_context,
         const boost::function<void(const RR_SHARED_PTR<RobotRaconteurException>&)>& callback);
@@ -175,13 +176,13 @@ class TcpTransportConnection : public detail::ASIOStreamBaseTransport
 #endif
 
 #ifdef ROBOTRACONTEUR_USE_OPENSSL
-    RR_SHARED_PTR<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> > tls_socket;
+    RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> > tls_socket;
     RR_SHARED_PTR<detail::OpenSSLAuthContext> tls_context;
-    RR_SHARED_PTR<boost::asio::ssl::stream<detail::websocket_stream<boost::asio::ip::tcp::socket&>&> > tls_websocket;
-    RR_SHARED_PTR<detail::websocket_stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>&> > wss_websocket;
-    RR_SHARED_PTR<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> > wss_websocket_tls;
+    RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<detail::websocket_stream<boost::asio::ip::tcp::socket&>&> > tls_websocket;
+    RR_SHARED_PTR<detail::websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> > wss_websocket;
+    RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> > wss_websocket_tls;
     RR_SHARED_PTR<
-        boost::asio::ssl::stream<detail::websocket_stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>&>&> >
+        detail::asio_ssl_stream_threadsafe<detail::websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&>&> >
         tls_wss_websocket;
     RR_SHARED_PTR<boost::asio::ssl::context> wss_context;
 #endif
@@ -438,22 +439,22 @@ class TcpWSSWebSocketConnector : public RR_ENABLE_SHARED_FROM_THIS<TcpWSSWebSock
     void Connect4(
         const RR_SHARED_PTR<RobotRaconteurException>& err, const RR_SHARED_PTR<ITransportConnection>& connection,
         const RR_SHARED_PTR<boost::asio::ip::tcp::socket>& socket,
-        const RR_SHARED_PTR<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> >& tls_stream,
-        const RR_SHARED_PTR<websocket_stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>&> >& websocket,
+        const RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >& tls_stream,
+        const RR_SHARED_PTR<websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >& websocket,
         const boost::function<void(const RR_SHARED_PTR<ITransportConnection>&,
                                    const RR_SHARED_PTR<RobotRaconteurException>&)>& handler);
 
     void Connect3(
         const boost::system::error_code& ec, const RR_SHARED_PTR<boost::asio::ip::tcp::socket>& socket,
         const RR_SHARED_PTR<boost::signals2::scoped_connection>& socket_closer,
-        const RR_SHARED_PTR<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> >& tls_stream,
-        const RR_SHARED_PTR<websocket_stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>&> >& websocket,
+        const RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >& tls_stream,
+        const RR_SHARED_PTR<websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >& websocket,
         const boost::function<void(const RR_SHARED_PTR<ITransportConnection>&,
                                    const RR_SHARED_PTR<RobotRaconteurException>&)>& handler);
 
     void Connect2_1(const boost::system::error_code& ec, const RR_SHARED_PTR<boost::asio::ip::tcp::socket>& socket,
                     const RR_SHARED_PTR<boost::signals2::scoped_connection>& socket_closer,
-                    const RR_SHARED_PTR<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> >& tls_stream,
+                    const RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >& tls_stream,
                     const boost::function<void(const RR_SHARED_PTR<ITransportConnection>&,
                                                const RR_SHARED_PTR<RobotRaconteurException>&)>& handler);
 

--- a/RobotRaconteurCore/src/TcpTransport_private.h
+++ b/RobotRaconteurCore/src/TcpTransport_private.h
@@ -65,7 +65,8 @@ class TcpTransportConnection : public detail::ASIOStreamBaseTransport
     void AsyncAttachWSSWebSocket(
         const RR_SHARED_PTR<boost::asio::ip::tcp::socket>& socket,
         const RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >& wss_websocket_tls,
-        const RR_SHARED_PTR<detail::websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >&
+        const RR_SHARED_PTR<
+            detail::websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >&
             wss_websocket,
         const RR_SHARED_PTR<boost::asio::ssl::context>& wss_context,
         const boost::function<void(const RR_SHARED_PTR<RobotRaconteurException>&)>& callback);
@@ -178,11 +179,13 @@ class TcpTransportConnection : public detail::ASIOStreamBaseTransport
 #ifdef ROBOTRACONTEUR_USE_OPENSSL
     RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> > tls_socket;
     RR_SHARED_PTR<detail::OpenSSLAuthContext> tls_context;
-    RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<detail::websocket_stream<boost::asio::ip::tcp::socket&>&> > tls_websocket;
-    RR_SHARED_PTR<detail::websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> > wss_websocket;
+    RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<detail::websocket_stream<boost::asio::ip::tcp::socket&>&> >
+        tls_websocket;
+    RR_SHARED_PTR<detail::websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >
+        wss_websocket;
     RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> > wss_websocket_tls;
-    RR_SHARED_PTR<
-        detail::asio_ssl_stream_threadsafe<detail::websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&>&> >
+    RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<
+        detail::websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&>&> >
         tls_wss_websocket;
     RR_SHARED_PTR<boost::asio::ssl::context> wss_context;
 #endif
@@ -440,7 +443,8 @@ class TcpWSSWebSocketConnector : public RR_ENABLE_SHARED_FROM_THIS<TcpWSSWebSock
         const RR_SHARED_PTR<RobotRaconteurException>& err, const RR_SHARED_PTR<ITransportConnection>& connection,
         const RR_SHARED_PTR<boost::asio::ip::tcp::socket>& socket,
         const RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >& tls_stream,
-        const RR_SHARED_PTR<websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >& websocket,
+        const RR_SHARED_PTR<websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >&
+            websocket,
         const boost::function<void(const RR_SHARED_PTR<ITransportConnection>&,
                                    const RR_SHARED_PTR<RobotRaconteurException>&)>& handler);
 
@@ -448,7 +452,8 @@ class TcpWSSWebSocketConnector : public RR_ENABLE_SHARED_FROM_THIS<TcpWSSWebSock
         const boost::system::error_code& ec, const RR_SHARED_PTR<boost::asio::ip::tcp::socket>& socket,
         const RR_SHARED_PTR<boost::signals2::scoped_connection>& socket_closer,
         const RR_SHARED_PTR<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&> >& tls_stream,
-        const RR_SHARED_PTR<websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >& websocket,
+        const RR_SHARED_PTR<websocket_stream<detail::asio_ssl_stream_threadsafe<boost::asio::ip::tcp::socket&>&> >&
+            websocket,
         const boost::function<void(const RR_SHARED_PTR<ITransportConnection>&,
                                    const RR_SHARED_PTR<RobotRaconteurException>&)>& handler);
 

--- a/RobotRaconteurCore/src/TlsSchannelStreamAdapter.h
+++ b/RobotRaconteurCore/src/TlsSchannelStreamAdapter.h
@@ -170,6 +170,10 @@ class TlsSchannelAsyncStreamAdapter_ASIO_adapter
     void close();
 
     TlsSchannelAsyncStreamAdapter& lowest_layer() { return next_layer_; }
+
+    typedef typename TlsSchannelAsyncStreamAdapter lowest_layer_type;
+    typedef typename TlsSchannelAsyncStreamAdapter next_layer_type;
+    typedef typename RR_BOOST_ASIO_IO_CONTEXT::executor_type executor_type;
 };
 
 class TlsSchannelAsyncStreamAdapter : public boost::enable_shared_from_this<TlsSchannelAsyncStreamAdapter>,
@@ -314,6 +318,12 @@ class TlsSchannelAsyncStreamAdapter : public boost::enable_shared_from_this<TlsS
     void set_mutual_auth(bool mutual_auth);
 
     TlsSchannelAsyncStreamAdapter_ASIO_adapter& get_asio_adapter() { return asio_adapter; }
+
+    typedef typename TlsSchannelAsyncStreamAdapter lowest_layer_type;
+    typedef typename TlsSchannelAsyncStreamAdapter next_layer_type;
+    typedef typename RR_BOOST_ASIO_IO_CONTEXT::executor_type executor_type;
+
+    executor_type get_executor() { return _io_context.get_executor(); }
 };
 } // namespace detail
 } // namespace RobotRaconteur

--- a/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
+++ b/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
@@ -27,7 +27,7 @@ class asio_ssl_stream_threadsafe
     class handler_wrapper
     {
       public:
-        typedef typename boost::remove_reference<Handler>::type HandlerValueType;
+        typedef typename std::remove_const<typename boost::remove_reference<Handler>::type>::type HandlerValueType;
 
         handler_wrapper(const Handler& handler, RR_BOOST_ASIO_NEW_API_CONST Executor& executor)
             : handler_(handler), executor_(executor)

--- a/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
+++ b/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
@@ -12,47 +12,82 @@ namespace detail
 
         typedef typename boost::remove_reference<boost::asio::ssl::stream<Stream> >::type next_layer_type;
         typedef typename next_layer_type::lowest_layer_type lowest_layer_type;
-        typedef typename lowest_layer_type::executor_type executor_type;
         typedef typename next_layer_type::native_handle_type native_handle_type;
-    
+
+#if BOOST_ASIO_VERSION >= 101200
+        typedef typename lowest_layer_type::executor_type executor_type;
+#else
+        typedef boost::asio::io_service executor_type;
+#endif
     protected:    
         boost::asio::ssl::stream<Stream> ssl_stream_;
         boost::asio::ssl::context& context_;
-        boost::asio::strand<executor_type> strand_;
+        RR_BOOST_ASIO_STRAND2(executor_type) strand_;
+
+        template <typename Handler, typename Executor>
+        class handler_wrapper
+        {
+        public:
+            typedef typename boost::remove_reference<Handler>::type HandlerValueType;
+
+            handler_wrapper(const Handler& handler, Executor& executor) : handler_(RR_MOVE(handler)),
+                executor_(executor) {}
+
+            void operator()(const boost::system::error_code& ec, const std::size_t& bytes_transferred)
+            {
+                boost::asio::detail::binder2<HandlerValueType, boost::system::error_code, std::size_t>
+                handler(handler_, ec, bytes_transferred);
+#if BOOST_ASIO_VERSION >= 101200
+                boost::asio::post(boost::asio::get_associated_executor(handler, executor_),handler);
+#else
+                executor_.post(handler);
+#endif
+            }
+
+        private:
+            HandlerValueType handler_;
+#if BOOST_ASIO_VERSION >= 101200
+            Executor executor_;
+#else
+            boost::asio::io_service& executor_;
+#endif
+        };
 
     public:
 
         asio_ssl_stream_threadsafe(Stream& stream, boost::asio::ssl::context& context)
-            : ssl_stream_(stream, context), context_(context), strand_(boost::asio::make_strand(stream.get_executor()))
+            : ssl_stream_(stream, context), context_(context), strand_(RR_BOOST_ASIO_MAKE_STRAND(RR_BOOST_ASIO_GET_IO_SERVICE(stream)))
         {
         }
 
         // async_read_some using strand for callback
         template <typename MutableBufferSequence, typename ReadHandler>
-        void async_read_some(const MutableBufferSequence& buffers, ReadHandler&& handler)
+        void async_read_some(const MutableBufferSequence& buffers, RR_MOVE_ARG(ReadHandler) handler)
         {
-            ssl_stream_.async_read_some(buffers, boost::asio::bind_executor(strand_,std::forward<ReadHandler>(handler)));
+            handler_wrapper<ReadHandler, executor_type> handler2(boost::ref(handler), RR_BOOST_ASIO_GET_IO_SERVICE((*this)));
+            ssl_stream_.async_read_some(buffers, RR_BOOST_ASIO_STRAND_WRAP(strand_,RR_MOVE(handler2)));
         }
 
         // async_write_some using strand for callback
         template <typename ConstBufferSequence, typename WriteHandler>
-        void async_write_some(const ConstBufferSequence& buffers, WriteHandler&& handler)
+        void async_write_some(const ConstBufferSequence& buffers, RR_MOVE_ARG(WriteHandler) handler)
         {
-            ssl_stream_.async_write_some(buffers, boost::asio::bind_executor(strand_, std::forward<WriteHandler>(handler)));
+            handler_wrapper<WriteHandler, executor_type> handler2(boost::ref(handler), RR_BOOST_ASIO_GET_IO_SERVICE((*this)));
+            ssl_stream_.async_write_some(buffers, RR_BOOST_ASIO_STRAND_WRAP(strand_, RR_MOVE(handler2)));
         }
 
         // async_handshake using strand for callback
         template <typename HandshakeHandler>
-        void async_handshake(boost::asio::ssl::stream_base::handshake_type type, HandshakeHandler&& handler)
+        void async_handshake(boost::asio::ssl::stream_base::handshake_type type, RR_MOVE_ARG(HandshakeHandler) handler)
         {
-            ssl_stream_.async_handshake(type, boost::asio::bind_executor(strand_, std::forward<HandshakeHandler>(handler)));
+            ssl_stream_.async_handshake(type, RR_BOOST_ASIO_STRAND_WRAP(strand_, RR_FORWARD(HandshakeHandler, handler)));
         }
 
         // async_shutdown using strand for callback
         template <typename ShutdownHandler>
-        void async_shutdown(ShutdownHandler&& handler)
+        void async_shutdown(RR_MOVE_ARG(ShutdownHandler) handler)
         {
-            ssl_stream_.async_shutdown(boost::asio::bind_executor(strand_, std::forward<ShutdownHandler>(handler)));
+            ssl_stream_.async_shutdown(RR_BOOST_ASIO_STRAND_WRAP(strand_, RR_FORWARD(ShutdownHandler, handler)));
         }
 
         native_handle_type native_handle()
@@ -75,10 +110,14 @@ namespace detail
             ssl_stream_.set_verify_mode(v);
         }
 
-        executor_type get_executor() noexcept
+#if BOOST_ASIO_VERSION >= 101200
+        executor_type get_executor() BOOST_ASIO_NOEXCEPT
         {
             return ssl_stream_.lowest_layer().get_executor();
-        }           
+        }
+#else
+        boost::asio::io_service& get_io_service() { return ssl_stream_.lowest_layer().get_io_service(); }
+#endif
 
     };
 }

--- a/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
+++ b/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
@@ -30,7 +30,7 @@ namespace detail
         public:
             typedef typename boost::remove_reference<Handler>::type HandlerValueType;
 
-            handler_wrapper(const Handler& handler, Executor& executor) : handler_(RR_MOVE(handler)),
+            handler_wrapper(const Handler& handler, const Executor& executor) : handler_(handler),
                 executor_(executor) {}
 
             void operator()(const boost::system::error_code& ec, const std::size_t& bytes_transferred)

--- a/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
+++ b/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
@@ -56,7 +56,7 @@ class asio_ssl_stream_threadsafe
   public:
     asio_ssl_stream_threadsafe(Stream& stream, boost::asio::ssl::context& context)
         : ssl_stream_(stream, context), context_(context),
-          strand_(RR_BOOST_ASIO_MAKE_STRAND(executor_type,RR_BOOST_ASIO_GET_IO_SERVICE(stream)))
+          strand_(RR_BOOST_ASIO_MAKE_STRAND(executor_type, RR_BOOST_ASIO_GET_IO_SERVICE(stream)))
     {}
 
     // async_read_some using strand for callback

--- a/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
+++ b/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
@@ -1,0 +1,85 @@
+#include <boost/asio/ssl.hpp>
+
+namespace RobotRaconteur
+{
+namespace detail
+{
+    template <typename Stream>
+    class asio_ssl_stream_threadsafe
+    {
+    
+    public:
+
+        typedef typename boost::remove_reference<boost::asio::ssl::stream<Stream> >::type next_layer_type;
+        typedef typename next_layer_type::lowest_layer_type lowest_layer_type;
+        typedef typename lowest_layer_type::executor_type executor_type;
+        typedef typename next_layer_type::native_handle_type native_handle_type;
+    
+    protected:    
+        boost::asio::ssl::stream<Stream> ssl_stream_;
+        boost::asio::ssl::context& context_;
+        boost::asio::strand<executor_type> strand_;
+
+    public:
+
+        asio_ssl_stream_threadsafe(Stream& stream, boost::asio::ssl::context& context)
+            : ssl_stream_(stream, context), context_(context), strand_(boost::asio::make_strand(stream.get_executor()))
+        {
+        }
+
+        // async_read_some using strand for callback
+        template <typename MutableBufferSequence, typename ReadHandler>
+        void async_read_some(const MutableBufferSequence& buffers, ReadHandler&& handler)
+        {
+            ssl_stream_.async_read_some(buffers, boost::asio::bind_executor(strand_,std::forward<ReadHandler>(handler)));
+        }
+
+        // async_write_some using strand for callback
+        template <typename ConstBufferSequence, typename WriteHandler>
+        void async_write_some(const ConstBufferSequence& buffers, WriteHandler&& handler)
+        {
+            ssl_stream_.async_write_some(buffers, boost::asio::bind_executor(strand_, std::forward<WriteHandler>(handler)));
+        }
+
+        // async_handshake using strand for callback
+        template <typename HandshakeHandler>
+        void async_handshake(boost::asio::ssl::stream_base::handshake_type type, HandshakeHandler&& handler)
+        {
+            ssl_stream_.async_handshake(type, boost::asio::bind_executor(strand_, std::forward<HandshakeHandler>(handler)));
+        }
+
+        // async_shutdown using strand for callback
+        template <typename ShutdownHandler>
+        void async_shutdown(ShutdownHandler&& handler)
+        {
+            ssl_stream_.async_shutdown(boost::asio::bind_executor(strand_, std::forward<ShutdownHandler>(handler)));
+        }
+
+        native_handle_type native_handle()
+        {
+            return ssl_stream_.native_handle();
+        }
+
+        lowest_layer_type& lowest_layer()
+        {
+            return ssl_stream_.lowest_layer();
+        }
+
+        next_layer_type& next_layer()
+        {
+            return ssl_stream_;
+        }
+
+        void set_verify_mode(boost::asio::ssl::verify_mode v)
+        {
+            ssl_stream_.set_verify_mode(v);
+        }
+
+        executor_type get_executor() noexcept
+        {
+            return ssl_stream_.lowest_layer().get_executor();
+        }           
+
+    };
+}
+}

--- a/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
+++ b/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
@@ -27,7 +27,7 @@ class asio_ssl_stream_threadsafe
     class handler_wrapper // NOLINT(bugprone-exception-escape)
     {
       public:
-        typedef typename std::remove_const<typename boost::remove_reference<Handler>::type>::type HandlerValueType;
+        typedef typename boost::remove_const<typename boost::remove_reference<Handler>::type>::type HandlerValueType;
 
         handler_wrapper(const Handler& handler, RR_BOOST_ASIO_NEW_API_CONST Executor& executor)
             : handler_(handler), executor_(executor)

--- a/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
+++ b/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
@@ -4,121 +4,106 @@ namespace RobotRaconteur
 {
 namespace detail
 {
-    template <typename Stream>
-    class asio_ssl_stream_threadsafe
+template <typename Stream>
+class asio_ssl_stream_threadsafe
+{
+
+  public:
+    typedef typename boost::remove_reference<boost::asio::ssl::stream<Stream> >::type next_layer_type;
+    typedef typename next_layer_type::lowest_layer_type lowest_layer_type;
+    typedef typename next_layer_type::native_handle_type native_handle_type;
+
+#if BOOST_ASIO_VERSION >= 101200
+    typedef typename lowest_layer_type::executor_type executor_type;
+#else
+    typedef boost::asio::io_service executor_type;
+#endif
+  protected:
+    boost::asio::ssl::stream<Stream> ssl_stream_;
+    boost::asio::ssl::context& context_;
+    RR_BOOST_ASIO_STRAND2(executor_type) strand_;
+
+    template <typename Handler, typename Executor>
+    class handler_wrapper
     {
-    
-    public:
+      public:
+        typedef typename boost::remove_reference<Handler>::type HandlerValueType;
 
-        typedef typename boost::remove_reference<boost::asio::ssl::stream<Stream> >::type next_layer_type;
-        typedef typename next_layer_type::lowest_layer_type lowest_layer_type;
-        typedef typename next_layer_type::native_handle_type native_handle_type;
+        handler_wrapper(const Handler& handler, RR_BOOST_ASIO_NEW_API_CONST Executor& executor)
+            : handler_(handler), executor_(executor)
+        {}
 
+        void operator()(const boost::system::error_code& ec, const std::size_t& bytes_transferred)
+        {
+            boost::asio::detail::binder2<HandlerValueType, boost::system::error_code, std::size_t> handler(
+                handler_, ec, bytes_transferred);
 #if BOOST_ASIO_VERSION >= 101200
-        typedef typename lowest_layer_type::executor_type executor_type;
+            boost::asio::post(boost::asio::get_associated_executor(handler, executor_), handler);
 #else
-        typedef boost::asio::io_service executor_type;
+            executor_.post(handler);
 #endif
-    protected:    
-        boost::asio::ssl::stream<Stream> ssl_stream_;
-        boost::asio::ssl::context& context_;
-        RR_BOOST_ASIO_STRAND2(executor_type) strand_;
+        }
 
-        template <typename Handler, typename Executor>
-        class handler_wrapper
-        {
-        public:
-            typedef typename boost::remove_reference<Handler>::type HandlerValueType;
-
-            handler_wrapper(const Handler& handler, RR_BOOST_ASIO_NEW_API_CONST Executor& executor) : handler_(handler),
-                executor_(executor) {}
-
-            void operator()(const boost::system::error_code& ec, const std::size_t& bytes_transferred)
-            {
-                boost::asio::detail::binder2<HandlerValueType, boost::system::error_code, std::size_t>
-                handler(handler_, ec, bytes_transferred);
+      private:
+        HandlerValueType handler_;
 #if BOOST_ASIO_VERSION >= 101200
-                boost::asio::post(boost::asio::get_associated_executor(handler, executor_),handler);
+        Executor executor_;
 #else
-                executor_.post(handler);
+        boost::asio::io_service& executor_;
 #endif
-            }
-
-        private:
-            HandlerValueType handler_;
-#if BOOST_ASIO_VERSION >= 101200
-            Executor executor_;
-#else
-            boost::asio::io_service& executor_;
-#endif
-        };
-
-    public:
-
-        asio_ssl_stream_threadsafe(Stream& stream, boost::asio::ssl::context& context)
-            : ssl_stream_(stream, context), context_(context), strand_(RR_BOOST_ASIO_MAKE_STRAND(RR_BOOST_ASIO_GET_IO_SERVICE(stream)))
-        {
-        }
-
-        // async_read_some using strand for callback
-        template <typename MutableBufferSequence, typename ReadHandler>
-        void async_read_some(const MutableBufferSequence& buffers, RR_MOVE_ARG(ReadHandler) handler)
-        {
-            handler_wrapper<ReadHandler, executor_type> handler2(boost::ref(handler), RR_BOOST_ASIO_GET_IO_SERVICE((*this)));
-            ssl_stream_.async_read_some(buffers, RR_BOOST_ASIO_STRAND_WRAP(strand_,RR_MOVE(handler2)));
-        }
-
-        // async_write_some using strand for callback
-        template <typename ConstBufferSequence, typename WriteHandler>
-        void async_write_some(const ConstBufferSequence& buffers, RR_MOVE_ARG(WriteHandler) handler)
-        {
-            handler_wrapper<WriteHandler, executor_type> handler2(boost::ref(handler), RR_BOOST_ASIO_GET_IO_SERVICE((*this)));
-            ssl_stream_.async_write_some(buffers, RR_BOOST_ASIO_STRAND_WRAP(strand_, RR_MOVE(handler2)));
-        }
-
-        // async_handshake using strand for callback
-        template <typename HandshakeHandler>
-        void async_handshake(boost::asio::ssl::stream_base::handshake_type type, RR_MOVE_ARG(HandshakeHandler) handler)
-        {
-            ssl_stream_.async_handshake(type, RR_BOOST_ASIO_STRAND_WRAP(strand_, RR_FORWARD(HandshakeHandler, handler)));
-        }
-
-        // async_shutdown using strand for callback
-        template <typename ShutdownHandler>
-        void async_shutdown(RR_MOVE_ARG(ShutdownHandler) handler)
-        {
-            ssl_stream_.async_shutdown(RR_BOOST_ASIO_STRAND_WRAP(strand_, RR_FORWARD(ShutdownHandler, handler)));
-        }
-
-        native_handle_type native_handle()
-        {
-            return ssl_stream_.native_handle();
-        }
-
-        lowest_layer_type& lowest_layer()
-        {
-            return ssl_stream_.lowest_layer();
-        }
-
-        next_layer_type& next_layer()
-        {
-            return ssl_stream_;
-        }
-
-        void set_verify_mode(boost::asio::ssl::verify_mode v)
-        {
-            ssl_stream_.set_verify_mode(v);
-        }
-
-#if BOOST_ASIO_VERSION >= 101200
-        executor_type get_executor() BOOST_ASIO_NOEXCEPT
-        {
-            return ssl_stream_.lowest_layer().get_executor();
-        }
-#else
-        boost::asio::io_service& get_io_service() { return ssl_stream_.lowest_layer().get_io_service(); }
-#endif
-
     };
-}
-}
+
+  public:
+    asio_ssl_stream_threadsafe(Stream& stream, boost::asio::ssl::context& context)
+        : ssl_stream_(stream, context), context_(context),
+          strand_(RR_BOOST_ASIO_MAKE_STRAND(RR_BOOST_ASIO_GET_IO_SERVICE(stream)))
+    {}
+
+    // async_read_some using strand for callback
+    template <typename MutableBufferSequence, typename ReadHandler>
+    void async_read_some(const MutableBufferSequence& buffers, RR_MOVE_ARG(ReadHandler) handler)
+    {
+        handler_wrapper<ReadHandler, executor_type> handler2(boost::ref(handler),
+                                                             RR_BOOST_ASIO_GET_IO_SERVICE((*this)));
+        ssl_stream_.async_read_some(buffers, RR_BOOST_ASIO_STRAND_WRAP(strand_, RR_MOVE(handler2)));
+    }
+
+    // async_write_some using strand for callback
+    template <typename ConstBufferSequence, typename WriteHandler>
+    void async_write_some(const ConstBufferSequence& buffers, RR_MOVE_ARG(WriteHandler) handler)
+    {
+        handler_wrapper<WriteHandler, executor_type> handler2(boost::ref(handler),
+                                                              RR_BOOST_ASIO_GET_IO_SERVICE((*this)));
+        ssl_stream_.async_write_some(buffers, RR_BOOST_ASIO_STRAND_WRAP(strand_, RR_MOVE(handler2)));
+    }
+
+    // async_handshake using strand for callback
+    template <typename HandshakeHandler>
+    void async_handshake(boost::asio::ssl::stream_base::handshake_type type, RR_MOVE_ARG(HandshakeHandler) handler)
+    {
+        ssl_stream_.async_handshake(type, RR_BOOST_ASIO_STRAND_WRAP(strand_, RR_FORWARD(HandshakeHandler, handler)));
+    }
+
+    // async_shutdown using strand for callback
+    template <typename ShutdownHandler>
+    void async_shutdown(RR_MOVE_ARG(ShutdownHandler) handler)
+    {
+        ssl_stream_.async_shutdown(RR_BOOST_ASIO_STRAND_WRAP(strand_, RR_FORWARD(ShutdownHandler, handler)));
+    }
+
+    native_handle_type native_handle() { return ssl_stream_.native_handle(); }
+
+    lowest_layer_type& lowest_layer() { return ssl_stream_.lowest_layer(); }
+
+    next_layer_type& next_layer() { return ssl_stream_; }
+
+    void set_verify_mode(boost::asio::ssl::verify_mode v) { ssl_stream_.set_verify_mode(v); }
+
+#if BOOST_ASIO_VERSION >= 101200
+    executor_type get_executor() BOOST_ASIO_NOEXCEPT { return ssl_stream_.lowest_layer().get_executor(); }
+#else
+    boost::asio::io_service& get_io_service() { return ssl_stream_.lowest_layer().get_io_service(); }
+#endif
+};
+} // namespace detail
+} // namespace RobotRaconteur

--- a/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
+++ b/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
@@ -30,7 +30,7 @@ namespace detail
         public:
             typedef typename boost::remove_reference<Handler>::type HandlerValueType;
 
-            handler_wrapper(const Handler& handler, const Executor& executor) : handler_(handler),
+            handler_wrapper(const Handler& handler, RR_BOOST_ASIO_NEW_API_CONST Executor& executor) : handler_(handler),
                 executor_(executor) {}
 
             void operator()(const boost::system::error_code& ec, const std::size_t& bytes_transferred)

--- a/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
+++ b/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
@@ -56,7 +56,7 @@ class asio_ssl_stream_threadsafe
   public:
     asio_ssl_stream_threadsafe(Stream& stream, boost::asio::ssl::context& context)
         : ssl_stream_(stream, context), context_(context),
-          strand_(RR_BOOST_ASIO_MAKE_STRAND(RR_BOOST_ASIO_GET_IO_SERVICE(stream)))
+          strand_(RR_BOOST_ASIO_MAKE_STRAND(executor_type,RR_BOOST_ASIO_GET_IO_SERVICE(stream)))
     {}
 
     // async_read_some using strand for callback

--- a/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
+++ b/RobotRaconteurCore/src/asio_ssl_stream_threadsafe.h
@@ -24,7 +24,7 @@ class asio_ssl_stream_threadsafe
     RR_BOOST_ASIO_STRAND2(executor_type) strand_;
 
     template <typename Handler, typename Executor>
-    class handler_wrapper
+    class handler_wrapper // NOLINT(bugprone-exception-escape)
     {
       public:
         typedef typename std::remove_const<typename boost::remove_reference<Handler>::type>::type HandlerValueType;

--- a/RobotRaconteurCore/src/websocket_stream.hpp
+++ b/RobotRaconteurCore/src/websocket_stream.hpp
@@ -66,14 +66,14 @@ class websocket_stream : private boost::noncopyable
         WebSocketOpcode_pong = 0xA
     };
 
-#ifdef ROBOTRACONTEUR_USE_OPENSSL
+
     typedef typename boost::remove_reference<Stream>::type next_layer_type;
     typedef typename next_layer_type::lowest_layer_type lowest_layer_type;
 
     lowest_layer_type& lowest_layer() { return next_layer_.lowest_layer(); }
 
     const lowest_layer_type& lowest_layer() const { return next_layer_.lowest_layer(); }
-#endif
+
 
   protected:
     boost::mutex random_lock;
@@ -1535,7 +1535,7 @@ class websocket_stream : private boost::noncopyable
       public:
         typedef typename boost::remove_reference<Handler>::type HandlerValueType;
 
-        handler_wrapper(const Handler& handler, Executor& executor) : handler_(RR_MOVE(handler)),
+        handler_wrapper(const Handler& handler, const Executor& executor) : handler_(handler),
             executor_(executor) {}
 
         void do_complete(const boost::system::error_code& ec, const std::size_t& bytes_transferred)

--- a/RobotRaconteurCore/src/websocket_stream.hpp
+++ b/RobotRaconteurCore/src/websocket_stream.hpp
@@ -81,7 +81,7 @@ class websocket_stream : private boost::noncopyable
 
   public:
 #if BOOST_ASIO_VERSION >= 101200
-    typedef RR_BOOST_ASIO_IO_CONTEXT executor_type;
+    typedef typename lowest_layer_type::executor_type executor_type;
     executor_type get_executor() BOOST_ASIO_NOEXCEPT { return next_layer_.get_executor(); }
 #endif
 

--- a/RobotRaconteurCore/src/websocket_stream.hpp
+++ b/RobotRaconteurCore/src/websocket_stream.hpp
@@ -66,14 +66,12 @@ class websocket_stream : private boost::noncopyable
         WebSocketOpcode_pong = 0xA
     };
 
-
     typedef typename boost::remove_reference<Stream>::type next_layer_type;
     typedef typename next_layer_type::lowest_layer_type lowest_layer_type;
 
     lowest_layer_type& lowest_layer() { return next_layer_.lowest_layer(); }
 
     const lowest_layer_type& lowest_layer() const { return next_layer_.lowest_layer(); }
-
 
   protected:
     boost::mutex random_lock;
@@ -1535,27 +1533,29 @@ class websocket_stream : private boost::noncopyable
       public:
         typedef typename boost::remove_reference<Handler>::type HandlerValueType;
 
-        handler_wrapper(const Handler& handler, RR_BOOST_ASIO_NEW_API_CONST Executor& executor) : handler_(handler),
-            executor_(executor) {}
+        handler_wrapper(const Handler& handler, RR_BOOST_ASIO_NEW_API_CONST Executor& executor)
+            : handler_(handler), executor_(executor)
+        {}
 
         void do_complete(const boost::system::error_code& ec, const std::size_t& bytes_transferred)
         {
-            boost::asio::detail::binder2<HandlerValueType, boost::system::error_code, std::size_t>
-              handler(handler_, ec, bytes_transferred);
+            boost::asio::detail::binder2<HandlerValueType, boost::system::error_code, std::size_t> handler(
+                handler_, ec, bytes_transferred);
 #if BOOST_ASIO_VERSION >= 101200
-            boost::asio::post(boost::asio::get_associated_executor(handler, executor_),handler);
+            boost::asio::post(boost::asio::get_associated_executor(handler, executor_), handler);
 #else
             executor_.post(handler);
 #endif
-            // boost::asio::asio_handler_invoke(handler, boost::asio::detail::addressof(handler_), ec, bytes_transferred);
+            // boost::asio::asio_handler_invoke(handler, boost::asio::detail::addressof(handler_), ec,
+            // bytes_transferred);
         }
 
       private:
         HandlerValueType handler_;
 #if BOOST_ASIO_VERSION >= 101200
-            Executor executor_;
+        Executor executor_;
 #else
-            boost::asio::io_service& executor_;
+        boost::asio::io_service& executor_;
 #endif
     };
 
@@ -1582,7 +1582,8 @@ class websocket_stream : private boost::noncopyable
 
         // TODO: use more than first buffer
         boost::shared_ptr<handler_wrapper<Handler, executor_type> > handler2 =
-            boost::make_shared<handler_wrapper<Handler, executor_type> >(boost::ref(handler), RR_BOOST_ASIO_REF_IO_SERVICE(RR_BOOST_ASIO_GET_IO_SERVICE((*this))));
+            boost::make_shared<handler_wrapper<Handler, executor_type> >(
+                boost::ref(handler), RR_BOOST_ASIO_REF_IO_SERVICE(RR_BOOST_ASIO_GET_IO_SERVICE((*this))));
         async_read_some2(
             boost::asio::detail::buffer_sequence_adapter<boost::asio::mutable_buffer, MutableBufferSequence>::first(
                 buffers),
@@ -1594,7 +1595,8 @@ class websocket_stream : private boost::noncopyable
     void async_write_some(const const_buffers& buffers, BOOST_ASIO_MOVE_ARG(Handler) handler)
     {
         boost::shared_ptr<handler_wrapper<Handler, executor_type> > handler2 =
-            boost::make_shared<handler_wrapper<Handler, executor_type> >(boost::ref(handler), RR_BOOST_ASIO_REF_IO_SERVICE(RR_BOOST_ASIO_GET_IO_SERVICE((*this))));
+            boost::make_shared<handler_wrapper<Handler, executor_type> >(
+                boost::ref(handler), RR_BOOST_ASIO_REF_IO_SERVICE(RR_BOOST_ASIO_GET_IO_SERVICE((*this))));
         if (ping_requested)
         {
             boost::shared_array<uint8_t> ping_data2;
@@ -1625,8 +1627,8 @@ class websocket_stream : private boost::noncopyable
         {
             // TODO: use more than first buffer
             async_write_message(DataFrameType, buffers,
-                                boost::bind(&handler_wrapper<Handler, executor_type>::do_complete, handler2, RR_BOOST_PLACEHOLDERS(_1),
-                                            RR_BOOST_PLACEHOLDERS(_2)));
+                                boost::bind(&handler_wrapper<Handler, executor_type>::do_complete, handler2,
+                                            RR_BOOST_PLACEHOLDERS(_1), RR_BOOST_PLACEHOLDERS(_2)));
         }
     }
 

--- a/RobotRaconteurCore/src/websocket_stream.hpp
+++ b/RobotRaconteurCore/src/websocket_stream.hpp
@@ -82,7 +82,10 @@ class websocket_stream : private boost::noncopyable
   public:
 #if BOOST_ASIO_VERSION >= 101200
     typedef typename lowest_layer_type::executor_type executor_type;
-    executor_type get_executor() BOOST_ASIO_NOEXCEPT { return next_layer_.get_executor(); }
+    executor_type get_executor() BOOST_ASIO_NOEXCEPT { return next_layer_.lowest_layer().get_executor(); }
+#else
+    typedef typename boost::asio::io_service executor_type;
+    boost::asio::io_service& get_io_service() { return next_layer_.lowest_layer().get_io_service(); }
 #endif
 
     websocket_stream(Stream& next_layer)
@@ -1526,24 +1529,34 @@ class websocket_stream : private boost::noncopyable
     size_t ping_data_len;
     boost::mutex ping_lock;
 
-    template <typename Handler>
+    template <typename Handler, typename Executor>
     class handler_wrapper
     {
       public:
         typedef typename boost::remove_reference<Handler>::type HandlerValueType;
 
-        handler_wrapper(const Handler& handler) : handler_(static_cast<const Handler&>(handler)) {}
+        handler_wrapper(const Handler& handler, Executor& executor) : handler_(RR_MOVE(handler)),
+            executor_(executor) {}
 
         void do_complete(const boost::system::error_code& ec, const std::size_t& bytes_transferred)
         {
-            // boost::asio::detail::binder2<Handler, boost::system::error_code, std::size_t>
-            // handler(handler_, ec, bytes_transferred);
-            // boost_asio_handler_invoke_helpers::invoke(handler, handler.handler_);
-            handler_(ec, bytes_transferred);
+            boost::asio::detail::binder2<HandlerValueType, boost::system::error_code, std::size_t>
+              handler(handler_, ec, bytes_transferred);
+#if BOOST_ASIO_VERSION >= 101200
+            boost::asio::post(boost::asio::get_associated_executor(handler, executor_),handler);
+#else
+            executor_.post(handler);
+#endif
+            // boost::asio::asio_handler_invoke(handler, boost::asio::detail::addressof(handler_), ec, bytes_transferred);
         }
 
       private:
         HandlerValueType handler_;
+#if BOOST_ASIO_VERSION >= 101200
+            Executor executor_;
+#else
+            boost::asio::io_service& executor_;
+#endif
     };
 
   public:
@@ -1568,20 +1581,20 @@ class websocket_stream : private boost::noncopyable
         }
 
         // TODO: use more than first buffer
-        boost::shared_ptr<handler_wrapper<Handler> > handler2 =
-            boost::make_shared<handler_wrapper<Handler> >(boost::ref(handler));
+        boost::shared_ptr<handler_wrapper<Handler, executor_type> > handler2 =
+            boost::make_shared<handler_wrapper<Handler, executor_type> >(boost::ref(handler), RR_BOOST_ASIO_REF_IO_SERVICE(RR_BOOST_ASIO_GET_IO_SERVICE((*this))));
         async_read_some2(
             boost::asio::detail::buffer_sequence_adapter<boost::asio::mutable_buffer, MutableBufferSequence>::first(
                 buffers),
-            boost::bind(&handler_wrapper<Handler>::do_complete, handler2, RR_BOOST_PLACEHOLDERS(_1),
+            boost::bind(&handler_wrapper<Handler, executor_type>::do_complete, handler2, RR_BOOST_PLACEHOLDERS(_1),
                         RR_BOOST_PLACEHOLDERS(_2)));
     }
 
     template <typename Handler>
     void async_write_some(const const_buffers& buffers, BOOST_ASIO_MOVE_ARG(Handler) handler)
     {
-        boost::shared_ptr<handler_wrapper<Handler> > handler2 =
-            boost::make_shared<handler_wrapper<Handler> >(boost::ref(handler));
+        boost::shared_ptr<handler_wrapper<Handler, executor_type> > handler2 =
+            boost::make_shared<handler_wrapper<Handler, executor_type> >(boost::ref(handler), RR_BOOST_ASIO_REF_IO_SERVICE(RR_BOOST_ASIO_GET_IO_SERVICE((*this))));
         if (ping_requested)
         {
             boost::shared_array<uint8_t> ping_data2;
@@ -1605,14 +1618,14 @@ class websocket_stream : private boost::noncopyable
                     boost::asio::placeholders::bytes_transferred, ping_data2, ping_data_len2, 0,
                     boost::asio::detail::buffer_sequence_adapter<boost::asio::const_buffer, const_buffers>::first(
                         buffers),
-                    boost::protect(boost::bind(&handler_wrapper<Handler>::do_complete, handler2,
+                    boost::protect(boost::bind(&handler_wrapper<Handler, executor_type>::do_complete, handler2,
                                                RR_BOOST_PLACEHOLDERS(_1), RR_BOOST_PLACEHOLDERS(_2)))));
         }
         else
         {
             // TODO: use more than first buffer
             async_write_message(DataFrameType, buffers,
-                                boost::bind(&handler_wrapper<Handler>::do_complete, handler2, RR_BOOST_PLACEHOLDERS(_1),
+                                boost::bind(&handler_wrapper<Handler, executor_type>::do_complete, handler2, RR_BOOST_PLACEHOLDERS(_1),
                                             RR_BOOST_PLACEHOLDERS(_2)));
         }
     }

--- a/RobotRaconteurCore/src/websocket_stream.hpp
+++ b/RobotRaconteurCore/src/websocket_stream.hpp
@@ -1531,7 +1531,7 @@ class websocket_stream : private boost::noncopyable
     class handler_wrapper
     {
       public:
-        typedef typename boost::remove_reference<Handler>::type HandlerValueType;
+        typedef typename std::remove_const<typename boost::remove_reference<Handler>::type>::type HandlerValueType;
 
         handler_wrapper(const Handler& handler, RR_BOOST_ASIO_NEW_API_CONST Executor& executor)
             : handler_(handler), executor_(executor)

--- a/RobotRaconteurCore/src/websocket_stream.hpp
+++ b/RobotRaconteurCore/src/websocket_stream.hpp
@@ -1531,7 +1531,7 @@ class websocket_stream : private boost::noncopyable
     class handler_wrapper
     {
       public:
-        typedef typename std::remove_const<typename boost::remove_reference<Handler>::type>::type HandlerValueType;
+        typedef typename boost::remove_const<typename boost::remove_reference<Handler>::type>::type HandlerValueType;
 
         handler_wrapper(const Handler& handler, RR_BOOST_ASIO_NEW_API_CONST Executor& executor)
             : handler_(handler), executor_(executor)

--- a/RobotRaconteurCore/src/websocket_stream.hpp
+++ b/RobotRaconteurCore/src/websocket_stream.hpp
@@ -1535,7 +1535,7 @@ class websocket_stream : private boost::noncopyable
       public:
         typedef typename boost::remove_reference<Handler>::type HandlerValueType;
 
-        handler_wrapper(const Handler& handler, const Executor& executor) : handler_(handler),
+        handler_wrapper(const Handler& handler, RR_BOOST_ASIO_NEW_API_CONST Executor& executor) : handler_(handler),
             executor_(executor) {}
 
         void do_complete(const boost::system::error_code& ec, const std::size_t& bytes_transferred)


### PR DESCRIPTION
Use boost::asio::strand to protect access to boost::asio::ssl::stream to prevent concurrency problems. Improve TcpTransport and websocket_stream to correctly support the strand. Introduce asio_ssl_stream_threadsafe wrapper to implement the strand protection.

This fix requires more context switches using boost::asio::post to deal with the strand. In the future it would be preferable to implement a custom OpenSSL interface that can better handle the multithreading architecture of this library.