### PR TITLE
Fix generator cleanup deadlock

### DIFF
--- a/RobotRaconteurCore/src/Service.cpp
+++ b/RobotRaconteurCore/src/Service.cpp
@@ -516,7 +516,7 @@ void ServiceSkel::SendGeneratorResponse(int32_t index, const RR_INTRUSIVE_PTR<Me
             }
             gen = e->second;
             if (m->Error == MessageErrorType_StopIteration)
-            {                
+            {
                 ROBOTRACONTEUR_LOG_DEBUG_COMPONENT_PATH(node, Service, e->second->GetEndpoint(), m_ServicePath, "",
                                                         "Destroying generator id " << e->first << " due to close");
             }

--- a/RobotRaconteurCore/src/Service.cpp
+++ b/RobotRaconteurCore/src/Service.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright 2011-2020 Wason Technology, LLC
+// Copyright 2011-2020 Wason Technology, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -538,6 +538,7 @@ void ServiceSkel::CleanupGenerators()
 {
     boost::posix_time::ptime destroy_time =
         boost::posix_time::second_clock::universal_time() - boost::posix_time::minutes(10);
+    std::list<RR_SHARED_PTR<GeneratorServerBase> > destroy_storage;
     boost::mutex::scoped_lock lock(generators_lock);
     for (boost::unordered_map<int32_t, RR_SHARED_PTR<GeneratorServerBase> >::iterator e = generators.begin();
          e != generators.end();)
@@ -546,6 +547,7 @@ void ServiceSkel::CleanupGenerators()
         {
             ROBOTRACONTEUR_LOG_DEBUG_COMPONENT_PATH(node, Service, e->second->GetEndpoint(), m_ServicePath, "",
                                                     "Destroying generator id " << e->first << " due to timeout");
+            destroy_storage.push_back(e->second);
             e = generators.erase(e);
         }
         else
@@ -553,6 +555,8 @@ void ServiceSkel::CleanupGenerators()
             ++e;
         }
     }
+    lock.unlock();
+    destroy_storage.clear();
 }
 
 RR_SHARED_PTR<ServiceFactory> ServerContext::GetServiceDef() const { return m_ServiceDef; }

--- a/RobotRaconteurCore/src/Service.cpp
+++ b/RobotRaconteurCore/src/Service.cpp
@@ -1,4 +1,4 @@
-// Copyright 2011-2020 Wason Technology, LLC
+﻿// Copyright 2011-2020 Wason Technology, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -504,9 +504,9 @@ void ServiceSkel::SendGeneratorResponse(int32_t index, const RR_INTRUSIVE_PTR<Me
 {
     ROBOTRACONTEUR_LOG_TRACE_COMPONENT_PATH(node, Service, ep->GetLocalEndpoint(), m_ServicePath, m->MemberName,
                                             "SendGeneratorResponse generator id: " << index);
+    RR_SHARED_PTR<GeneratorServerBase> gen;
     if (m->Error != MessageErrorType_None)
     {
-        RR_SHARED_PTR<GeneratorServerBase> gen;
         {
             boost::mutex::scoped_lock lock(generators_lock);
             boost::unordered_map<int32_t, RR_SHARED_PTR<GeneratorServerBase> >::iterator e = generators.find(index);
@@ -515,6 +515,17 @@ void ServiceSkel::SendGeneratorResponse(int32_t index, const RR_INTRUSIVE_PTR<Me
                 throw InvalidOperationException("Invalid generator");
             }
             gen = e->second;
+            if (m->Error == MessageErrorType_StopIteration)
+            {                
+                ROBOTRACONTEUR_LOG_DEBUG_COMPONENT_PATH(node, Service, e->second->GetEndpoint(), m_ServicePath, "",
+                                                        "Destroying generator id " << e->first << " due to close");
+            }
+            else
+            {
+                ROBOTRACONTEUR_LOG_DEBUG_COMPONENT_PATH(node, Service, e->second->GetEndpoint(), m_ServicePath, "",
+                                                        "Destroying generator id " << e->first << " due to error");
+            }
+            generators.erase(e);
         }
     }
 


### PR DESCRIPTION
A deadlock was occurring in ServiceSkel::CleanupGenerators() due to a deadlock between generators_lock and the Python GIL. This PR modifies the destruction order so that generators_lock is not held when the generator object is destroyed.

This PR also fixes generator destruction when an exception is returned.