### PR TITLE
Fix C++11 detection

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1136,7 +1136,7 @@ jobs:
     - name: configure
       working-directory: build2
       run: >
-        cmake -G "Unix Makefiles" -DBUILD_GEN=ON  -DBUILD_TESTING=OFF 
+        cmake -G "Unix Makefiles" -DBUILD_GEN=ON  -DBUILD_TESTING=OFF -DCMAKE_CXX_STANDARD=11
         -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON -DCMAKE_CXX_CLANG_TIDY=clang-tidy-14
         -DCMAKE_BUILD_TYPE=Debug
         ../robotraconteur

--- a/.gitlab/ci/wasontech/.gitlab-ci.yml
+++ b/.gitlab/ci/wasontech/.gitlab-ci.yml
@@ -458,7 +458,7 @@ clang_tidy_ubuntu_focal_amd64:
     - > 
       cmake -G Ninja
       -DCMAKE_BUILD_TYPE=Debug -DBoost_USE_STATIC_LIBS=OFF      
-      -DBUILD_GEN=ON -DBUILD_TESTING=OFF
+      -DBUILD_GEN=ON -DBUILD_TESTING=OFF -DCMAKE_CXX_STANDARD=11
       -DCMAKE_CXX_CLANG_TIDY=clang-tidy-14
       -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
       ..

--- a/RobotRaconteurCore/CMakeLists.txt
+++ b/RobotRaconteurCore/CMakeLists.txt
@@ -372,20 +372,19 @@ if(MSVC)
     target_compile_options(RobotRaconteurCore PRIVATE "/wd4251" "/wd4275" "/bigobj")
 endif()
 
-
-if (DEFINED CMAKE_CXX_STANDARD)
+if(DEFINED CMAKE_CXX_STANDARD)
     if(CMAKE_CXX_STANDARD GREATER_EQUAL 11 AND NOT CMAKE_CXX_STANDARD EQUAL 98)
         set(ROBOTRACONTEUR_USE_CXX11 TRUE)
     endif()
 endif()
 
-if (DEFINED MSVC_VERSION)
+if(DEFINED MSVC_VERSION)
     if(MSVC_VERSION GREATER_EQUAL 1900)
         set(ROBOTRACONTEUR_USE_CXX11 TRUE)
     endif()
 endif()
 
-if (NOT ROBOTRACONTEUR_USE_CXX11)
+if(NOT ROBOTRACONTEUR_USE_CXX11)
     target_compile_definitions(RobotRaconteurCore PUBLIC ROBOTRACONTEUR_NO_CXX11)
 endif()
 

--- a/RobotRaconteurCore/CMakeLists.txt
+++ b/RobotRaconteurCore/CMakeLists.txt
@@ -372,6 +372,23 @@ if(MSVC)
     target_compile_options(RobotRaconteurCore PRIVATE "/wd4251" "/wd4275" "/bigobj")
 endif()
 
+
+if (DEFINED CMAKE_CXX_STANDARD)
+    if(CMAKE_CXX_STANDARD GREATER_EQUAL 11 AND NOT CMAKE_CXX_STANDARD EQUAL 98)
+        set(ROBOTRACONTEUR_USE_CXX11 TRUE)
+    endif()
+endif()
+
+if (DEFINED MSVC_VERSION)
+    if(MSVC_VERSION GREATER_EQUAL 1900)
+        set(ROBOTRACONTEUR_USE_CXX11 TRUE)
+    endif()
+endif()
+
+if (NOT ROBOTRACONTEUR_USE_CXX11)
+    target_compile_definitions(RobotRaconteurCore PUBLIC ROBOTRACONTEUR_NO_CXX11)
+endif()
+
 target_include_directories(
     RobotRaconteurCore PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                               $<INSTALL_INTERFACE:include/> # <prefix>/include/

--- a/RobotRaconteurCore/include/RobotRaconteur/RobotRaconteurConfig.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/RobotRaconteurConfig.h
@@ -114,7 +114,7 @@
 #endif
 
 // Use Boost ASIO move detection
-#if __cplusplus >= 201103L
+#ifndef ROBOTRACONTEUR_NO_CXX11
 #define RR_MOVE_ARG(type) type&&
 #define RR_MOVE(x) std::move(x)
 #define RR_FORWARD(type, x) std::forward<type>(x)
@@ -173,7 +173,7 @@
 #define RR_MEMBER_ARRAY_INIT2(x)
 #endif
 
-#if __cplusplus >= 201103L
+#ifndef ROBOTRACONTEUR_NO_CXX11
 #define RR_OVERRIDE override
 #define RR_OVIRTUAL
 #else


### PR DESCRIPTION
Fix C++11 detection by using a compiler preprocessor directive `ROBOTRACONTEUR_NO_CXX11` instead of detecting using Boost and C++ macros. This will fix inconsistencies between library compilation and library usage which may vary depending on compiler flags.