### PR TITLE
Improve PipeSubscription::GetActivePipeEndpointCount() and WireSubscr…

### DIFF
--- a/test/python/RobotRaconteurTest/test_subscription_pipe.py
+++ b/test/python/RobotRaconteurTest/test_subscription_pipe.py
@@ -107,7 +107,12 @@ def test_pipe_subscription():
         pipe_sub.PipePacketReceived += packet_recv
         sub.GetDefaultClientWait(5)
 
-        assert pipe_sub.ActivePipeEndpointCount > 0
+        for _ in range(10):
+            if pipe_sub.ActivePipeEndpointCount > 0:
+                break
+            time.sleep(0.01)
+        else:
+            assert False
 
         with pytest.raises(RR.InvalidOperationException):
             pipe_sub.ReceivePacket()

--- a/test/python/RobotRaconteurTest/test_subscription_wire.py
+++ b/test/python/RobotRaconteurTest/test_subscription_wire.py
@@ -96,7 +96,12 @@ def test_wire_subscription():
         wire_sub.WireValueChanged += value_changed
         sub.GetDefaultClientWait(5)
 
-        assert wire_sub.ActiveWireConnectionCount > 0
+        for _ in range(10):
+            if wire_sub.ActiveWireConnectionCount > 0:
+                break
+            time.sleep(0.01)
+        else:
+            assert False
 
         with pytest.raises(RR.ValueNotSetException):
             _ = wire_sub.InValue
@@ -124,6 +129,8 @@ def test_wire_subscription():
         assert wire_sub.InValue == 6.0
 
         wire_sub2 = sub.SubscribeWire("testwire3", "*.subobj")
+
+        time.sleep(0.05)
 
         assert wire_sub2.ActiveWireConnectionCount > 0
 

--- a/test/python/RobotRaconteurTest/test_subscription_wire.py
+++ b/test/python/RobotRaconteurTest/test_subscription_wire.py
@@ -116,7 +116,12 @@ def test_wire_subscription():
         assert wire_sub.InValue == 5.0
         assert wire_sub.TryGetInValue()[1] == 5.0
 
-        assert value_changed_count[0] > 0
+        for _ in range(10):
+            if value_changed_count[0] > 0:
+                break
+            time.sleep(0.01)
+        else:
+            assert False
 
         wire_sub.InValueLifespan = 0.1
         assert wire_sub.InValueLifespan == 0.1


### PR DESCRIPTION
…iption::GetActiveWireConnectionCount

Previously the member subscription active counts were returning the size of the connections data structure and not checking if the connections had been completed. Updated to return the number of actually connected active connections.