### PR TITLE
Fix segfault in WireSubscription::GetInValue() when connection parameter is NULL

### DIFF
--- a/RobotRaconteurCore/include/RobotRaconteur/Subscription.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/Subscription.h
@@ -1250,7 +1250,7 @@ class WireSubscription : public WireSubscriptionBase
     {
         RR_SHARED_PTR<WireConnectionBase> connection1;
         T o = RRPrimUtil<T>::PreUnpack(GetInValueBase(time, &connection1));
-        if (connection1)
+        if (connection && connection1)
         {
             *connection = RR_DYNAMIC_POINTER_CAST<WireConnection<T> >(connection1);
         }

--- a/test/cpp/service/subscribertest.cpp
+++ b/test/cpp/service/subscribertest.cpp
@@ -111,6 +111,10 @@ int main(int argc, char* argv[])
     RR_INTRUSIVE_PTR<RobotRaconteur::RRArray<double> > w1_value;
     TimeSpec w1_time;
     broadcastwire->TryGetInValue(w1_value, &w1_time);
+    broadcastwire->TryGetInValue(w1_value);
+
+    broadcastwire->GetInValue(&w1_time);
+    broadcastwire->GetInValue();
 
     double pipe_val;
     while (broadcastpipe->TryReceivePacket(pipe_val))


### PR DESCRIPTION
Fixes #330 