### PR TITLE
Silence class-memaccess warning in AllocateEmptyRRArray

### DIFF
--- a/RobotRaconteurCore/include/RobotRaconteur/DataTypes.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/DataTypes.h
@@ -1144,7 +1144,7 @@ static RR_INTRUSIVE_PTR<RRArray<T> > AllocateEmptyRRArray(size_t length)
     RR_INTRUSIVE_PTR<RRArray<T> > o = AllocateRRArray<T>(length);
     if (length > 0)
     {
-        memset(o->data(), 0, length * sizeof(T));
+        memset(static_cast<void*>(o->data()), 0, length * sizeof(T));
     }
     return o;
 }


### PR DESCRIPTION
Silence class-memaccess warning in `AllocateEmptyRRArray()` caused by `memset` and  `cdouble` and `csingle` structs. These are simple structures with only two floating point fields so they can be safely memset.