### PR TITLE
Silence boost::asio::deadline_timer deprecation warning

### DIFF
--- a/RobotRaconteurCore/include/RobotRaconteur/RobotRaconteurConfig.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/RobotRaconteurConfig.h
@@ -90,8 +90,16 @@
 
 #ifndef ROBOTRACONTEUR_EMSCRIPTEN
 #include <boost/thread.hpp>
+#ifndef BOOST_ASIO_DISABLE_DEPRECATED_MSG
+#define BOOST_ASIO_DISABLE_DEPRECATED_MSG
+#define RR_BOOST_ASIO_DISABLE_DEPRECATED_MSG
+#endif
 #include <boost/asio/version.hpp>
 #include <boost/asio/strand.hpp>
+#ifdef RR_BOOST_ASIO_DISABLE_DEPRECATED_MSG
+#undef RR_BOOST_ASIO_DISABLE_DEPRECATED_MSG
+#undef BOOST_ASIO_DISABLE_DEPRECATED_MSG
+#endif
 #endif
 
 #ifdef ROBOTRACONTEUR_WINDOWS

--- a/RobotRaconteurCore/include/RobotRaconteur/Timer.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/Timer.h
@@ -25,7 +25,16 @@
 #include "RobotRaconteur/DataTypes.h"
 
 #ifndef ROBOTRACONTEUR_EMSCRIPTEN
+#include <boost/thread.hpp>
+#ifndef BOOST_ASIO_DISABLE_DEPRECATED_MSG
+#define BOOST_ASIO_DISABLE_DEPRECATED_MSG
+#define RR_BOOST_ASIO_DISABLE_DEPRECATED_MSG
+#endif
 #include <boost/asio/deadline_timer.hpp>
+#ifdef RR_BOOST_ASIO_DISABLE_DEPRECATED_MSG
+#undef RR_BOOST_ASIO_DISABLE_DEPRECATED_MSG
+#undef BOOST_ASIO_DISABLE_DEPRECATED_MSG
+#endif
 #endif
 
 #include <boost/system/error_code.hpp>

--- a/RobotRaconteurCore/src/LocalTransport.cpp
+++ b/RobotRaconteurCore/src/LocalTransport.cpp
@@ -14,10 +14,6 @@
 
 #include "boost_asio_win_unix_sockets_backport.h"
 
-#include <boost/bind/placeholders.hpp>
-#include <boost/asio.hpp>
-#include <boost/assign/list_of.hpp>
-
 #ifdef ROBOTRACONTEUR_CORE_USE_STDAFX
 #include "stdafx.h"
 #endif
@@ -31,6 +27,9 @@
 
 #include <boost/scope_exit.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/bind/placeholders.hpp>
+#include <boost/asio.hpp>
+#include <boost/assign/list_of.hpp>
 
 #ifdef ROBOTRACONTEUR_WINDOWS
 #include <Shlobj.h>

--- a/RobotRaconteurCore/src/OpenSSLAuthContext.h
+++ b/RobotRaconteurCore/src/OpenSSLAuthContext.h
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "RobotRaconteur/RobotRaconteurConfig.h"
 #include <boost/asio/ssl.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>

--- a/RobotRaconteurCore/src/Tap.cpp
+++ b/RobotRaconteurCore/src/Tap.cpp
@@ -14,11 +14,6 @@
 
 #include "boost_asio_win_unix_sockets_backport.h"
 
-#include <boost/bind/placeholders.hpp>
-#include <boost/asio.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/shared_array.hpp>
-
 #include "RobotRaconteur/RobotRaconteurNode.h"
 
 #include "NodeDirectories_private.h"
@@ -26,6 +21,11 @@
 #include "RobotRaconteur/Tap.h"
 
 #include "RobotRaconteur/IOUtils.h"
+
+#include <boost/bind/placeholders.hpp>
+#include <boost/asio.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/shared_array.hpp>
 
 namespace RobotRaconteur
 {


### PR DESCRIPTION
boost::asio::deadline_timer is showing as deprecated. However, deadline_timer is in the public API so it cannot be easily modified. Silence warning for now.