### PR TITLE
Silence overloaded-virtual warning in Error.h

### DIFF
--- a/RobotRaconteurCore/include/RobotRaconteur/Error.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/Error.h
@@ -32,6 +32,11 @@ namespace RobotRaconteur
 
 class ROBOTRACONTEUR_CORE_API RRValue;
 
+#if defined(__GNUC__) || defined(__clang__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
+
 /**
  * @brief Base class for Robot Raconteur exceptions
  *
@@ -132,6 +137,10 @@ class ROBOTRACONTEUR_CORE_API RobotRaconteurException : public std::runtime_erro
   private:
     std::string what_string;
 };
+
+#if defined(__GNUC__) || defined(__clang__)
+    #pragma GCC diagnostic pop
+#endif
 
 // clang-format off
 #define RR_EXCEPTION_TYPES_INIT(M,M2) \

--- a/RobotRaconteurCore/include/RobotRaconteur/Error.h
+++ b/RobotRaconteurCore/include/RobotRaconteur/Error.h
@@ -32,9 +32,11 @@ namespace RobotRaconteur
 
 class ROBOTRACONTEUR_CORE_API RRValue;
 
+// cSpell: ignore Woverloaded
+
 #if defined(__GNUC__) || defined(__clang__)
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 #endif
 
 /**
@@ -139,7 +141,7 @@ class ROBOTRACONTEUR_CORE_API RobotRaconteurException : public std::runtime_erro
 };
 
 #if defined(__GNUC__) || defined(__clang__)
-    #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
 #endif
 
 // clang-format off


### PR DESCRIPTION
RobotRaconteurException::ToString() is declared non-const, but service definition exceptions ToString() is declared const. This is causing a `overloaded-virtual` warning in newer GCC versions. This problem cannot easily be fixed without changing the ABI. ToString() is not used, as what() is preferred.