### PR TITLE
Set RequestTimeout to 30 seconds in ServiceTestClient2.py

### DIFF
--- a/test/python/RobotRaconteurTest/ServiceTestClient2.py
+++ b/test/python/RobotRaconteurTest/ServiceTestClient2.py
@@ -61,6 +61,7 @@ class ServiceTestClient2:
         self.DisconnectService()
 
     def ConnectService(self, url):
+        RRN.RequestTimeout = 30
         self._r = RRN.ConnectService(url)
 
     def DisconnectService(self):


### PR DESCRIPTION
service_test2.py::test_pods() has been occasionally timing out. This test is computationally heavy generating test data using the test sequence generator. This PR increases the timeout to 30 seconds.