### PR TITLE
Use ios vcpkg revision 2026.06.01

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1162,6 +1162,7 @@ jobs:
         extra-args: --clean-after-build --overlay-triplets=${{ github.workspace }}/robotraconteur/tools/build_files/triplets
         cache-key: ${{ runner.os }}-arm64-ios-vcpkg
         token: ${{ github.token }}
+        revision: 2026.06.01
     - name: configure
       run: >
         cmake -DBUILD_TESTING=OFF -DBUILD_GEN=OFF -S robotraconteur -B build2


### PR DESCRIPTION
`libiconv` for iOS is not compiling in the most recent vcpkg release 2026.06.24 due to https://github.com/microsoft/vcpkg/issues/52351 . Fall back to 2026.06.01 for iOS until it is resolved.